### PR TITLE
fix gromacs gpu metadata description

### DIFF
--- a/applications/gromacs_gpu/metadata.yaml
+++ b/applications/gromacs_gpu/metadata.yaml
@@ -2,4 +2,4 @@
 id: "gromacs_application" # needs to be **unique** per application, changing results in a new application
 name: "GROMACS (GPU)"
 category: "OTHER"
-description: "... put description here ..."
+description: "Run GROMACS benchmarks from https://zenodo.org/records/3893789 on GPU"


### PR DESCRIPTION
The gromacs catalog workflow was missing a description in the metadata