### PR TITLE
new workflow template: LLM client/server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 # macos hidden files
 .DS_Store
+
+# local python environments
+.venv

--- a/applications/llm_client_server/data/queries.yaml
+++ b/applications/llm_client_server/data/queries.yaml
@@ -1,0 +1,33 @@
+# Sample queries for OpenAI chat completions API
+# This file contains a list of queries to run against the API
+
+# Example query 1 - Simple geography question
+- description: "Geography question about France"
+  messages:
+    - role: "system"
+      content: "You are a geography professor and hobby tour guide keen to provide a lot of highly accurate statistics and pet facts about locations including recommendations for places to visit. All facts have to be accurate."
+    - role: "user"
+      content: "What is the capital of France?"
+  temperature: 0.2
+
+# Example query 2 - Different system prompt, different question
+- description: "Programming question about Python"
+  messages:
+    - role: "system"
+      content: "You are a helpful programming assistant specializing in Python. Provide concise, accurate answers with code examples when appropriate."
+    - role: "user"
+      content: "How do I read a YAML file in Python?"
+  temperature: 0.1
+
+# Example query 3 - Multi-turn conversation
+- description: "Travel recommendations for Japan"
+  messages:
+    - role: "system"
+      content: "You are a travel advisor with expertise in Japanese culture, history, and tourist attractions. Provide personalized recommendations based on the interests of the traveler."
+    - role: "user"
+      content: "I'm planning a trip to Japan for two weeks. What are the must-visit places?"
+    - role: "assistant"
+      content: "Japan offers incredible variety! For a two-week trip, I recommend focusing on key regions. Tokyo is essential for its blend of ultramodern and traditional. Kyoto offers historic temples, traditional geisha districts, and beautiful gardens. Osaka is known for food and nightlife. In Hiroshima, visit the Peace Memorial. Consider day trips to Nara, Hakone for Mount Fuji views, or Nikko for shrines. Would you like more specific recommendations based on your interests (history, food, nature, etc.)?"
+    - role: "user"
+      content: "I'm particularly interested in traditional Japanese culture and food. What specific places would you recommend?"
+  temperature: 0.3

--- a/applications/llm_client_server/metadata.yaml
+++ b/applications/llm_client_server/metadata.yaml
@@ -3,9 +3,9 @@ id: "llm_client_server" # needs to be **unique** per application, changing resul
 name: "LLM client and server"
 category: "ML_AND_AI"
 description: >-
-  This workflow starts a OpenAI compatible REST API server implemented with
+  This workflow starts an OpenAI compatible REST API server implemented with
   vLLM (https://docs.vllm.ai/en/stable) using a model downloaded from
-  HuggingFace (https://huggingface.co/) in one job and then runs a series of
+  HuggingFace (https://huggingface.co/) in one job, and then runs a series of
   queries against the server from a second job in the same workflow. See
   https://docs.vllm.ai/en/stable/models/supported_models.html#supported-models
   for supported models. Once queries are done, the server is shut down.

--- a/applications/llm_client_server/metadata.yaml
+++ b/applications/llm_client_server/metadata.yaml
@@ -1,6 +1,6 @@
 # Copyright 2025 CIQ, Inc. All rights reserved.
 id: "llm_client_server" # needs to be **unique** per application, changing results in a new application
-name: "LLM client/server"
+name: "LLM client and server"
 category: "ML_AND_AI"
 description: >-
   This workflow starts a OpenAI compatible REST API server implemented with

--- a/applications/llm_client_server/metadata.yaml
+++ b/applications/llm_client_server/metadata.yaml
@@ -1,11 +1,11 @@
 # Copyright 2025 CIQ, Inc. All rights reserved.
 id: "llm_client_server" # needs to be **unique** per application, changing results in a new application
 name: "LLM client/server"
-category: "AI"
+category: "ML_AND_AI"
 description: >-
   This workflow starts a OpenAI compatible REST API server implemented with
   vLLM (https://docs.vllm.ai/en/stable) using a model downloaded from
   HuggingFace (https://huggingface.co/) in one job and then runs a series of
   queries against the server from a second job in the same workflow. See
   https://docs.vllm.ai/en/stable/models/supported_models.html#supported-models
-  for supported models. A final job takes care to shut down the API server.
+  for supported models. Once queries are done, the server is shut down.

--- a/applications/llm_client_server/metadata.yaml
+++ b/applications/llm_client_server/metadata.yaml
@@ -1,0 +1,11 @@
+# Copyright 2025 CIQ, Inc. All rights reserved.
+id: "llm_client_server" # needs to be **unique** per application, changing results in a new application
+name: "LLM client/server"
+category: "AI"
+description: >-
+  This workflow starts a OpenAI compatible REST API server implemented with
+  vLLM (https://docs.vllm.ai/en/stable) using a model downloaded from
+  HuggingFace (https://huggingface.co/) in one job and then runs a series of
+  queries against the server from a second job in the same workflow. See
+  https://docs.vllm.ai/en/stable/models/supported_models.html#supported-models
+  for supported models. A final job takes care to shut down the API server.

--- a/applications/llm_client_server/scripts/client.py
+++ b/applications/llm_client_server/scripts/client.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""
+OpenAI client
+"""
+
+import argparse
+import logging
+import os
+import socket
+import sys
+import time
+import yaml
+import textwrap
+from typing import Any, Dict, List
+import openai
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(name)-12s %(levelname)-8s %(message)s",
+    datefmt="%Y%m%d %H:%M:%S",
+)
+log = logging.getLogger("llm_client_server.client")
+
+
+class EnvDefault(argparse.Action):
+    def __init__(
+        self, envvar: str, required: bool = True, default: Any = None, **kwargs
+    ):
+        if envvar:
+            if envvar in os.environ:
+                default = os.environ[envvar]
+        if required and default:
+            required = False
+        super(EnvDefault, self).__init__(default=default, required=required, **kwargs)
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        setattr(namespace, self.dest, values)
+
+
+def parse_arguments() -> argparse.Namespace:
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--port",
+        type=int,
+        action=EnvDefault,
+        envvar="FBS_PORT",
+        help="Port for the server nanny [FBS_PORT]",
+    )
+    parser.add_argument(
+        "--key",
+        type=str,
+        action=EnvDefault,
+        envvar="FBS_KEY",
+        help="Key for the server nanny [FBS_KEY]",
+    )
+    parser.add_argument(
+        "--api-job",
+        type=str,
+        action=EnvDefault,
+        envvar="FBS_API_JOB",
+        help="Name of job running OpenAI compatible REST API [FBS_API_JOB]",
+    )
+    parser.add_argument(
+        "--api-port",
+        type=int,
+        action=EnvDefault,
+        envvar="FBS_API_PORT",
+        help="Port for OpenAI compatible REST API [FBS_API_PORT]",
+    )
+    parser.add_argument(
+        "--api-key",
+        type=str,
+        action=EnvDefault,
+        envvar="FBS_API_KEY",
+        help="KEY for OpenAI compatible REST API [FBS_API_KEY]",
+    )
+    parser.add_argument(
+        "--api-model",
+        type=str,
+        action=EnvDefault,
+        envvar="FBS_API_MODEL",
+        help="HuggingFace model served by host [FBS_API_MODEL]",
+    )
+    parser.add_argument(
+        "--queries-file",
+        type=str,
+        action=EnvDefault,
+        envvar="FBS_API_QUERIES",
+        help="YAML file containing queries to run",
+        default="queries.yaml",
+    )
+    return parser.parse_args()
+
+
+def load_queries(file_path: str) -> List[Dict]:
+    """Load queries from a YAML file."""
+    try:
+        with open(file_path, "r") as file:
+            queries = yaml.safe_load(file)
+            if not isinstance(queries, list):
+                log.error(f"Queries file {file_path} must contain a list of queries")
+                sys.exit(1)
+            return queries
+    except FileNotFoundError:
+        log.error(f"Queries file {file_path} not found")
+        sys.exit(1)
+    except yaml.YAMLError as e:
+        log.error(f"Error parsing YAML file {file_path}: {e}")
+        sys.exit(1)
+
+
+def run_query(client, model: str, query: Dict, query_index: int):
+    """Run a single query and print the result."""
+    if not isinstance(query, dict) or "messages" not in query:
+        log.error(
+            f"Query {query_index} is invalid. Each query must have a 'messages' key."
+        )
+        return
+
+    messages = query.get("messages", [])
+    temperature = query.get("temperature", 0.2)
+
+    try:
+        completion = client.chat.completions.create(
+            model=model,
+            messages=messages,
+            temperature=temperature,
+        )
+
+        query_desc = f"Query {query_index + 1}"
+        if "description" in query:
+            query_desc += f": {query['description']}"
+
+        print(f"\n### {query_desc} {'#' * 40}")
+
+        for msg in messages:
+            role = msg.get("role", "")
+            content = msg.get("content", "")
+            if role and content:
+                short_content = content[:50] + "..." if len(content) > 50 else content
+                print(f"{role.upper()}: {short_content}")
+
+        print("\nRESPONSE:")
+        print(textwrap.fill(completion.choices[0].message.content))
+
+    except Exception as e:
+        log.error(f"Error running query {query_index}: {e}")
+
+
+def shutdown_server(host: str, port: int, key: str):
+    """
+    Sends the server the shutdown message.
+    """
+    try:
+        client_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        client_socket.connect((host, port))
+        client_socket.sendall(f"exit:{key}".encode("utf-8"))
+    except socket.error as e:
+        log.error(f"Socket error: {e}")
+    except Exception as e:
+        log.error(f"Unexpected error occurred: {e}")
+    finally:
+        client_socket.close()
+
+
+if __name__ == "__main__":
+    args = parse_arguments()
+    openai_api_base = f"http://{args.api_job}:{args.api_port}/v1"
+    client = openai.OpenAI(
+        api_key=args.api_key,
+        base_url=openai_api_base,
+    )
+
+    # wait for server to be up
+    while True:
+        try:
+            models = client.models.list()
+        except openai.APIConnectionError:
+            log.info("Waiting for server to become available")
+            time.sleep(30)
+        except openai.AuthenticationError:
+            log.error("not authorized to access OpenAI server. This should not happen.")
+            shutdown_server(args.api_job, args.port, args.key)
+            sys.exit(1)
+        except Exception as e:
+            log.error(f"Unexpected error: {e}")
+            shutdown_server(args.api_job, args.port, args.key)
+            sys.exit(1)
+        else:
+            log.info("Server is ready")
+            break
+
+    queries = load_queries(args.queries_file)
+    log.info(f"Loaded {len(queries)} queries from {args.queries_file}")
+
+    for i, query in enumerate(queries):
+        run_query(client, args.api_model, query, i)
+
+    shutdown_server(args.api_job, args.port, args.key)
+
+    sys.exit(0)

--- a/applications/llm_client_server/scripts/client.py
+++ b/applications/llm_client_server/scripts/client.py
@@ -209,5 +209,6 @@ if __name__ == "__main__":
         p.parent.mkdir(parents=True, exist_ok=True)
         with open(p, "w", encoding="utf-8") as outfh:
             yaml.dump(results, outfh, width=100, indent=4)
+        log.info(f"saved results to {args.results_file}")
 
     sys.exit(0)

--- a/applications/llm_client_server/scripts/server.py
+++ b/applications/llm_client_server/scripts/server.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""
+Start a vllm server as a subprocess and listen to an exit command
+on a separate port. When exit is received, shut down the server
+and listening thread and exit. The exit command is in the format
+'exit:KEY'.
+"""
+
+import argparse
+import logging
+import threading
+import socket
+import subprocess
+import sys
+import os
+import time
+import secrets
+from typing import Optional, Any
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(name)-12s %(levelname)-8s %(message)s",
+    datefmt="%Y%m%d %H:%M:%S",
+)
+log = logging.getLogger("llm_client_server.server")
+
+
+class EnvDefault(argparse.Action):
+    def __init__(
+        self, envvar: str, required: bool = True, default: Any = None, **kwargs
+    ):
+        if envvar:
+            if envvar in os.environ:
+                default = os.environ[envvar]
+        if required and default:
+            required = False
+        super(EnvDefault, self).__init__(default=default, required=required, **kwargs)
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        setattr(namespace, self.dest, values)
+
+
+def start_server_process(model: str, port: int, key: str) -> subprocess.Popen:
+    """Start the server as a subprocess and redirect output to stdout."""
+
+    server_process = subprocess.Popen(
+        ["vllm", "serve", f"--port={port}", f"--api-key={key}", model],
+        stdout=sys.stdout,
+        stderr=sys.stderr,
+        text=True,
+    )
+    return server_process
+
+
+def command_listener(
+    server_process: subprocess.Popen, port: int, secret_key: str
+) -> None:
+    """Listen for commands on port with API key authentication."""
+    server_socket: socket.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    server_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    server_socket.bind(("0.0.0.0", port))
+    server_socket.listen(1)
+
+    try:
+        while not shutdown_event.is_set():
+            # Set a timeout so we can check the shutdown_event periodically
+            server_socket.settimeout(1.0)
+            try:
+                # accept blocks until a client connects
+                client_socket, client_address = server_socket.accept()
+                client_socket.settimeout(1.0)
+
+                data: str = client_socket.recv(1024).decode("utf-8").strip()
+                command_parts = data.split(":", 1)
+
+                # silently ignore invalid commands
+                if len(command_parts) == 2:
+                    command, received_key = command_parts
+
+                    # Secure comparison using constant time to prevent timing attacks
+                    if command.lower() == "exit" and secrets.compare_digest(
+                        received_key, secret_key
+                    ):
+                        # Set the shutdown event to signal all threads to exit
+                        shutdown_event.set()
+                        server_process.terminate()
+                        break
+
+                client_socket.close()
+            except socket.timeout:
+                continue
+            except Exception as e:
+                log.error(f"Error handling client connection: {e}")
+    finally:
+        server_socket.close()
+
+
+def parse_arguments() -> argparse.Namespace:
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--port",
+        type=int,
+        action=EnvDefault,
+        envvar="FBS_PORT",
+        help="Port for the server nanny [FBS_PORT]",
+    )
+    parser.add_argument(
+        "--key",
+        type=str,
+        action=EnvDefault,
+        envvar="FBS_KEY",
+        help="Key for the server nanny [FBS_KEY]",
+    )
+    parser.add_argument(
+        "--api-model",
+        type=str,
+        action=EnvDefault,
+        envvar="FBS_API_MODEL",
+        help="HuggingFace model to serve [FBS_API_MODEL]",
+    )
+    parser.add_argument(
+        "--api-key",
+        type=str,
+        action=EnvDefault,
+        envvar="FBS_API_KEY",
+        help="OpenAI-compatible REST API KEY [FBS_API_KEY]",
+    )
+    parser.add_argument(
+        "--api-port",
+        type=int,
+        action=EnvDefault,
+        envvar="FBS_API_PORT",
+        help="OpenAI-compatible REST API port [FBS_API_PORT]",
+    )
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_arguments()
+
+    # Event to signal shutdown to all threads
+    shutdown_event: threading.Event = threading.Event()
+
+    # Start server as a subprocess
+    server_process: subprocess.Popen = start_server_process(
+        args.api_model, args.api_port, args.api_key
+    )
+
+    # Start command listener in a separate thread
+    listener: threading.Thread = threading.Thread(
+        target=command_listener, args=(server_process, args.port, args.key)
+    )
+    listener.daemon = True
+    listener.start()
+
+    # Monitor the server process
+    while server_process.poll() is None and not shutdown_event.is_set():
+        time.sleep(1)
+
+    # If server terminated unexpectedly, set shutdown event
+    if not shutdown_event.is_set():
+        log.warning("Server process terminated unexpectedly")
+        shutdown_event.set()
+
+    # Wait for the server process to terminate
+    try:
+        exit_code: Optional[int] = server_process.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        log.warning("Server didn't terminate gracefully, killing...")
+        server_process.kill()
+
+    # Wait for the listener thread to finish
+    listener.join(timeout=2)
+
+    sys.exit(0)

--- a/applications/llm_client_server/template.yaml
+++ b/applications/llm_client_server/template.yaml
@@ -7,6 +7,8 @@
 {{- $workflow_script_uri := trim .WorkflowScriptUri }}
 {{- $query_data_uri := trim .QueryDataUri }}
 {{- $results_data_uri := trim .ResultsDataUri }}
+{{- $scratch_mount := "/scratch" }}
+{{- $data_mount := "/data" }}
 
 version: v1
 volumes:
@@ -44,11 +46,11 @@ jobs:
       uri: docker://vllm/vllm-openai:latest
     mounts:
       scratch:
-        location: /scratch
+        location: {{ $scratch_mount }}
       data:
-        location: /data
+        location: {{ $data_mount }}
     env:
-      - HF_HUB_CACHE=/data/{{ trim .HFHubCache }}
+      - HF_HUB_CACHE={{ $data_mount }}/{{ trim .HFHubCache }}
       - FBS_API_KEY={{ $vllm_api_key }}
       - FBS_API_PORT={{ $vllm_api_port }}
       - FBS_API_MODEL={{ trim .ModelName }}
@@ -57,7 +59,7 @@ jobs:
     command:
       - /bin/sh
       - "-c"
-      - python3 /scratch/job_scripts/${FB_JOB_NAME}.py
+      - python3 {{ $scratch_mount }}/job_scripts/${FB_JOB_NAME}.py
     resource:
       cpu:
         cores: {{ .ServerCores }}
@@ -74,25 +76,25 @@ jobs:
       uri: {{ .ClientImage }}
     mounts:
       scratch:
-        location: /scratch
+        location: {{ $scratch_mount }}
       data:
-        location: /data
+        location: {{ $data_mount }}
     env:
       - FBS_API_KEY={{ $vllm_api_key }}
       - FBS_API_PORT={{ $vllm_api_port }}
       - FBS_API_MODEL={{ trim .ModelName }}
       - FBS_API_JOB=server
-      - FBS_API_QUERIES=/scratch/queries.yaml
+      - FBS_API_QUERIES={{ $scratch_mount }}/queries.yaml
       - FBS_KEY={{ $key }}
       - FBS_PORT={{ $port }}
 {{- if $results_data_uri }}
 {{- if (hasPrefix "s3://" $results_data_uri) }}
-      - FBS_API_RESULTS=/scratch/results.yaml
+      - FBS_API_RESULTS={{ $scratch_mount }}/results.yaml
 {{- else }}
-      - FBS_API_RESULTS=/data/{{ $results_data_uri }}
+      - FBS_API_RESULTS={{ $data_mount }}/{{ $results_data_uri }}
 {{- end }}
 {{- end }}
     command:
       - /bin/sh
       - "-c"
-      - python3 /scratch/job_scripts/${FB_JOB_NAME}.py
+      - python3 {{ $scratch_mount }}/job_scripts/${FB_JOB_NAME}.py

--- a/applications/llm_client_server/template.yaml
+++ b/applications/llm_client_server/template.yaml
@@ -1,9 +1,9 @@
 # Copyright 2025 CIQ, Inc. All rights reserved.
 
 {{- $vllm_api_key := (randInt 0 100000 | toString) }}
-{{- $vllm_api_port := randInt 10000 20000 }}
+{{- $vllm_api_port := randInt 10000 12000 }}
 {{- $key := (randInt 0 100000 | toString) }}
-{{- $port := randInt 10000 20000 }}
+{{- $port := randInt 12001 14000 }}
 {{- $workflow_script_uri := trim .WorkflowScriptUri }}
 {{- $query_data_uri := trim .QueryDataUri }}
 {{- $results_data_uri := trim .ResultsDataUri }}

--- a/applications/llm_client_server/template.yaml
+++ b/applications/llm_client_server/template.yaml
@@ -34,7 +34,7 @@ volumes:
     egress:
       - source:
           uri: file://results.yaml
-      - destination:
+        destination:
           uri: {{ $results_data_uri }}
           secret: {{ .S3Secret }}
 {{- end }}

--- a/applications/llm_client_server/template.yaml
+++ b/applications/llm_client_server/template.yaml
@@ -75,6 +75,8 @@ jobs:
     mounts:
       scratch:
         location: /scratch
+      data:
+        location: /data
     env:
       - FBS_API_KEY={{ $vllm_api_key }}
       - FBS_API_PORT={{ $vllm_api_port }}

--- a/applications/llm_client_server/template.yaml
+++ b/applications/llm_client_server/template.yaml
@@ -6,6 +6,7 @@
 {{- $port := randInt 10000 20000 }}
 {{- $workflow_script_uri := trim .WorkflowScriptUri }}
 {{- $query_data_uri := trim .QueryDataUri }}
+{{- $results_data_uri := trim .ResultsDataUri }}
 
 version: v1
 volumes:
@@ -29,6 +30,14 @@ volumes:
           {{ if (and (hasPrefix "s3://" $query_data_uri ) .S3Secret) }}secret: {{ .S3Secret }}{{end}}
         destination:
           uri: file://queries.yaml
+{{- if (and $results_data_uri (hasPrefix "s3://" $results_data_uri)) }}
+    egress:
+      - source:
+          uri: file://results.yaml
+      - destination:
+          uri: {{ $results_data_uri }}
+          secret: {{ .S3Secret }}
+{{- end }}
 jobs:
   server:
     image:
@@ -74,6 +83,13 @@ jobs:
       - FBS_API_QUERIES=/scratch/queries.yaml
       - FBS_KEY={{ $key }}
       - FBS_PORT={{ $port }}
+{{- if $results_data_uri }}
+{{- if (hasPrefix "s3://" $results_data_uri) }}
+      - FBS_API_RESULTS=/scratch/results.yaml
+{{- else }}
+      - FBS_API_RESULTS=/data/{{ $results_data_uri }}
+{{- end }}
+{{- end }}
     command:
       - /bin/sh
       - "-c"

--- a/applications/llm_client_server/template.yaml
+++ b/applications/llm_client_server/template.yaml
@@ -1,0 +1,80 @@
+# Copyright 2025 CIQ, Inc. All rights reserved.
+
+{{- $vllm_api_key := (randInt 0 100000 | toString) }}
+{{- $vllm_api_port := randInt 10000 20000 }}
+{{- $key := (randInt 0 100000 | toString) }}
+{{- $port := randInt 10000 20000 }}
+{{- $workflow_script_uri := trim .WorkflowScriptUri }}
+{{- $query_data_uri := trim .QueryDataUri }}
+
+version: v1
+volumes:
+  data:
+    reference: {{ .DataVolume }}
+  scratch:
+    reference: {{ .ScratchVolume }}
+    ingress:
+      - source:
+          uri: {{ $workflow_script_uri }}/client.py
+          {{ if (and (hasPrefix "s3://" $workflow_script_uri ) .S3Secret) }}secret: {{ .S3Secret }}{{end}}
+        destination:
+          uri: file://job_scripts/client.py
+      - source:
+          uri: {{ $workflow_script_uri }}/server.py
+          {{ if (and (hasPrefix "s3://" $workflow_script_uri ) .S3Secret) }}secret: {{ .S3Secret }}{{end}}
+        destination:
+          uri: file://job_scripts/server.py
+      - source:
+          uri: {{ $query_data_uri }}
+          {{ if (and (hasPrefix "s3://" $query_data_uri ) .S3Secret) }}secret: {{ .S3Secret }}{{end}}
+        destination:
+          uri: file://queries.yaml
+jobs:
+  server:
+    image:
+      uri: docker://vllm/vllm-openai:latest
+    mounts:
+      scratch:
+        location: /scratch
+      data:
+        location: /data
+    env:
+      - HF_HUB_CACHE=/data/{{ trim .HFHubCache }}
+      - FBS_API_KEY={{ $vllm_api_key }}
+      - FBS_API_PORT={{ $vllm_api_port }}
+      - FBS_API_MODEL={{ trim .ModelName }}
+      - FBS_KEY={{ $key }}
+      - FBS_PORT={{ $port }}
+    command:
+      - /bin/sh
+      - "-c"
+      - python3 /scratch/job_scripts/${FB_JOB_NAME}.py
+    resource:
+      cpu:
+        cores: {{ .ServerCores }}
+        threads: true
+      devices:
+        nvidia.com/gpu: 1
+      memory:
+        size: {{ .ServerMemory }}
+    policy:
+      timeout:
+        execute: {{ .ServerTimeout }}
+  client:
+    image:
+      uri: {{ .ClientImage }}
+    mounts:
+      scratch:
+        location: /scratch
+    env:
+      - FBS_API_KEY={{ $vllm_api_key }}
+      - FBS_API_PORT={{ $vllm_api_port }}
+      - FBS_API_MODEL={{ trim .ModelName }}
+      - FBS_API_JOB=server
+      - FBS_API_QUERIES=/scratch/queries.yaml
+      - FBS_KEY={{ $key }}
+      - FBS_PORT={{ $port }}
+    command:
+      - /bin/sh
+      - "-c"
+      - python3 /scratch/job_scripts/${FB_JOB_NAME}.py

--- a/applications/llm_client_server/values.yaml
+++ b/applications/llm_client_server/values.yaml
@@ -17,10 +17,16 @@ values:
       See the documentation for the OpenAI API for chat completions for the format expected for 'messages'.
       http(s) and s3 are supported
     string_value: s3://co-ciq-misc-support/wresch/llm_client_server/queries.yaml
+  - name: ResultsDataUri
+    display_name: |
+      [optional] URI for a results file to write. Has to either be a s3:// URI or a path relative to the root
+      of the (persistent) DataVolume. It will contain the queries plus their results and the fuzzball workflow
+      id that generated the results.
+    string_value: results/llm/query-results.yaml
   - name: S3Secret
     display_name: |
-      Secret needed to fetch scripts and/or data if they are housed on S3. Will be used to fetch any scripts or data
-      files that start with s3:// protocol. Not needed if scripts and queries are via http(s).
+      [required for s3 transfers] Secret needed to fetch scripts and/or data if they are housed on S3. Will be used to
+      fetch any scripts or data files that start with s3:// protocol. Not needed if scripts and queries are via http(s).
     string_value: secret://user/s3
   - name: HFHubCache
     display_name: Path relative to the root of the DataVolume where the HuggingFace cache should be located.

--- a/applications/llm_client_server/values.yaml
+++ b/applications/llm_client_server/values.yaml
@@ -1,6 +1,6 @@
 values:
   - name: DataVolume
-    display_name: Volume to use for the huggingface cache. Ideally persistent to avoid unnecessary repeated downloads.
+    display_name: Volume to use for the huggingface cache. Ideally persistent to avoid unnecessary data transfers.
     string_value: volume://user/persistent
   - name: ScratchVolume
     display_name: Ephemeral volume for temporary data.
@@ -15,11 +15,12 @@ values:
       URI for a yaml file with queries to be executed by the client. The yaml file is a list of
       queries each containing a map with the keys 'description', 'messages', and 'temperature'.
       See the documentation for the OpenAI API for chat completions for the format expected for 'messages'.
+      http(s) and s3 are supported
     string_value: s3://co-ciq-misc-support/wresch/llm_client_server/queries.yaml
   - name: S3Secret
     display_name: |
       Secret needed to fetch scripts and/or data if they are housed on S3. Will be used to fetch any scripts or data
-      files that start with s3:// protocol. Not needed if scripts and queries are pulled with http(s).
+      files that start with s3:// protocol. Not needed if scripts and queries are via http(s).
     string_value: secret://user/s3
   - name: HFHubCache
     display_name: Path relative to the root of the DataVolume where the HuggingFace cache should be located.
@@ -38,6 +39,4 @@ values:
     string_value: 12GiB
   - name: ClientImage
     display_name: Container image to use for the client job
-    #string_value: docker://community.wave.seqera.io/library/curl_jq:86917bb60c968818
-    #string_value: docker://community.wave.seqera.io/library/pip_openai:3d1e40d2ad5483ff
     string_value: docker://community.wave.seqera.io/library/pip_pyyaml_openai:20672161f8e013fe

--- a/applications/llm_client_server/values.yaml
+++ b/applications/llm_client_server/values.yaml
@@ -9,14 +9,14 @@ values:
     display_name: |
       URI where scripts for each workflow job can be found. http(s) and s3 are supported.
       Scripts are named '<job>.py'.
-    string_value: s3://co-ciq-misc-support/wresch/llm_client_server
+    string_value: https://raw.githubusercontent.com/ctrliq/ciq-fuzzball-catalog/refs/heads/main/applications/llm_client_server/scripts
   - name: QueryDataUri
     display_name: |
       URI for a yaml file with queries to be executed by the client. The yaml file is a list of
       queries each containing a map with the keys 'description', 'messages', and 'temperature'.
       See the documentation for the OpenAI API for chat completions for the format expected for 'messages'.
       http(s) and s3 are supported
-    string_value: s3://co-ciq-misc-support/wresch/llm_client_server/queries.yaml
+    string_value: https://raw.githubusercontent.com/ctrliq/ciq-fuzzball-catalog/refs/heads/main/applications/llm_client_server/data/queries.yaml
   - name: ResultsDataUri
     display_name: |
       [optional] URI for a results file to write. Has to either be a s3:// URI or a path relative to the root

--- a/applications/llm_client_server/values.yaml
+++ b/applications/llm_client_server/values.yaml
@@ -1,0 +1,43 @@
+values:
+  - name: DataVolume
+    display_name: Volume to use for the huggingface cache. Ideally persistent to avoid unnecessary repeated downloads.
+    string_value: volume://user/persistent
+  - name: ScratchVolume
+    display_name: Ephemeral volume for temporary data.
+    string_value: volume://user/ephemeral
+  - name: WorkflowScriptUri
+    display_name: |
+      URI where scripts for each workflow job can be found. http(s) and s3 are supported.
+      Scripts are named '<job>.py'.
+    string_value: s3://co-ciq-misc-support/wresch/llm_client_server
+  - name: QueryDataUri
+    display_name: |
+      URI for a yaml file with queries to be executed by the client. The yaml file is a list of
+      queries each containing a map with the keys 'description', 'messages', and 'temperature'.
+      See the documentation for the OpenAI API for chat completions for the format expected for 'messages'.
+    string_value: s3://co-ciq-misc-support/wresch/llm_client_server/queries.yaml
+  - name: S3Secret
+    display_name: |
+      Secret needed to fetch scripts and/or data if they are housed on S3. Will be used to fetch any scripts or data
+      files that start with s3:// protocol. Not needed if scripts and queries are pulled with http(s).
+    string_value: secret://user/s3
+  - name: HFHubCache
+    display_name: Path relative to the root of the DataVolume where the HuggingFace cache should be located.
+    string_value: cache/huggingface
+  - name: ModelName
+    display_name: Name of the HuggingFace model to use.
+    string_value: HuggingFaceTB/SmolLM2-360M-Instruct
+  - name: ServerTimeout
+    display_name: Maximum runtime of server.
+    string_value: 2h
+  - name: ServerCores
+    display_name: Cores to allocate for the LLM server job.
+    uint_value: 4
+  - name: ServerMemory
+    display_name: Amount of memory to allocate for the LLM server job.
+    string_value: 12GiB
+  - name: ClientImage
+    display_name: Container image to use for the client job
+    #string_value: docker://community.wave.seqera.io/library/curl_jq:86917bb60c968818
+    #string_value: docker://community.wave.seqera.io/library/pip_openai:3d1e40d2ad5483ff
+    string_value: docker://community.wave.seqera.io/library/pip_pyyaml_openai:20672161f8e013fe


### PR DESCRIPTION
This is a significant evolution of the workflow written to demonstrate the use of a client/server LLM model in fuzzball:

- I am trying out a workflow implementation model where scripts for each step are fetched. The current draft request includes the scripts in the GitHub repo and i will update the defaults to fetch from there before it gets merged. In the meantime, for testing, scripts are pulled from S3
- The server is based on vLLM and can run any HuggingFace models supported by vLLM
- The server process now runs alongside a nanny which listens on a different port for a shutdown message with a key. This allows the client to signal server shutdown when it is done querying the server
- The client will process a list of queries read from a data file. An example data file is part of this PR. Again, for testing purposes, it currently pulls this from S3 but i will switch that to GitHub when it's ready to merge
- The scripts and data can be pulled from s3:// or http:// and the template will inject a secret only if the s3 protocol is used