### PR TITLE
Set -mpi arg in Ansys mech command

### DIFF
--- a/applications/ansys_mechanical/template.yaml
+++ b/applications/ansys_mechanical/template.yaml
@@ -12,7 +12,6 @@ jobs:
     cwd: /data
     env:
       - ANSYSLMD_LICENSE_FILE={{.AnsyslmdLicenseFile}}
-      - KMP_AFFINITY=disabled
     image:
       uri: {{.AnsysMechanicalContainerURI}}
       secret: {{.AnsysMechanicalContainerOciSecret}}
@@ -40,7 +39,7 @@ jobs:
         ANSYS_VERSION_NUMBER=$(echo ${ANSYS_VERSION/R/} | cut -c 3-);
         export LD_LIBRARY_PATH={{.AnsysInstallDir}}/v${ANSYS_VERSION_NUMBER}/Framework/bin/Linux64:$LD_LIBRARY_PATH;
 
-        {{.AnsysInstallDir}}/v${ANSYS_VERSION_NUMBER}/ansys/bin/ansys251 -b -i hip-implant-analysis.dat -np {{.MechanicalCores}};
+        {{.AnsysInstallDir}}/v${ANSYS_VERSION_NUMBER}/ansys/bin/ansys251 -b -i hip-implant-analysis.dat -np {{.MechanicalCores}} -mpi openmpi;
     resource:
       cpu:
         cores: {{.MechanicalCores}}


### PR DESCRIPTION
Previously, when running Ansys mechanical, the solve would error out if `KMP_AFFINITY` is not set. After working with Ansys support, I found that setting `-mpi openmpi` in the command and unsetting `KMP_AFFINITY` successfully runs the solver to completion. 