### PR TITLE
Remove comment in CFX workflow

### DIFF
--- a/applications/ansys_cfx/template.yaml
+++ b/applications/ansys_cfx/template.yaml
@@ -28,8 +28,14 @@ jobs:
 
         {{.AnsysInstallDir}}/{{$lver}}/v${ANSYS_VERSION_NUMBER}/CFX/bin/cfx5solve -def StaticMixer.def -par-dist "$(hostname)*{{.CfxCores}}";
 
-        # cat the latest output file
-        cat $(ls -1t StaticMixer_*.out 2>/dev/null | head -n 1)
+        LATEST_CFX_LOG_FILE=$(ls -1t StaticMixer_*.out 2>/dev/null | head -n 1)
+
+        if [ -n "$LATEST_CFX_LOG_FILE" ]; then
+          cat $LATEST_CFX_LOG_FILE;
+        else
+          echo "No CFX log files found.";
+        fi
+
     resource:
       cpu:
         cores: {{.CfxCores}}


### PR DESCRIPTION
When rendering the template, the cat command got wrapped into the comment and ended up not running. Add some logic here around getting the log file and outputting it in the workflow. 