### PR TITLE
Add Cloud Commander application

### DIFF
--- a/applications/cloudcommander/metadata.md
+++ b/applications/cloudcommander/metadata.md
@@ -5,5 +5,5 @@ name: "Fuzzball Cloud Commander File Browser"
 category: "UTILITIES"
 ---
 This application will start an instance of [Cloud
-Commander](https://cloudcmd.io/), a file browser which allows to to manage,
+Commander](https://cloudcmd.io/), a file browser which allows you to manage,
 preview, edit, download, and upload files in your Fuzzball persistent storage volumes.

--- a/applications/cloudcommander/metadata.md
+++ b/applications/cloudcommander/metadata.md
@@ -1,0 +1,9 @@
+# Copyright 2025 CIQ, Inc. All rights reserved.
+---
+id: "cloudcommander"
+name: "Fuzzball Cloud Commander File Browser"
+category: "UTILITIES"
+---
+This application will start an instance of [Cloud
+Commander](https://cloudcmd.io/), a file browser which allows to to manage,
+preview, edit, download, and upload files in your Fuzzball persistent storage volumes.

--- a/applications/cloudcommander/metadata.md
+++ b/applications/cloudcommander/metadata.md
@@ -7,3 +7,5 @@ category: "UTILITIES"
 This application will start an instance of [Cloud
 Commander](https://cloudcmd.io/), a file browser which allows you to manage,
 preview, edit, download, and upload files in your Fuzzball persistent storage volumes.
+
+To exit Cloud Commander press F2 to access the user menu and then hit `X`.

--- a/applications/cloudcommander/template.yaml
+++ b/applications/cloudcommander/template.yaml
@@ -25,7 +25,7 @@ jobs:
       - |
         port=$(( (RANDOM % 1000) + 8000 ))
         echo
-        echo "Access cloud commander requires port-forwarding via the CLI:"
+        echo "Access to cloud commander requires port-forwarding via the CLI:"
         echo
         echo "# fuzzball workflow port-forward ${FB_WORKFLOW_ID} cloud-commander $port:$port"
         echo

--- a/applications/cloudcommander/template.yaml
+++ b/applications/cloudcommander/template.yaml
@@ -42,7 +42,7 @@ jobs:
           --no-console \
           --username "$user" \
           --password "$pw" \
-          --auth 2>&1 > /dev/null
+          --auth > /dev/null 2>&1
 
     resource:
       cpu:

--- a/applications/cloudcommander/template.yaml
+++ b/applications/cloudcommander/template.yaml
@@ -24,14 +24,12 @@ jobs:
       - '-c'
       - |
         port=$(( (RANDOM % 1000) + 8000 ))
-        user="$(cat /dev/urandom | tr -d -c 'a-zA-Z0-9' | head -c10)"
-        pw="$(cat /dev/urandom | tr -d -c 'a-zA-Z0-9' | head -c10)"
         echo
         echo "Access cloud commander requires port-forwarding via the CLI:"
         echo
         echo "# fuzzball workflow port-forward ${FB_WORKFLOW_ID} cloud-commander $port:$port"
         echo
-        echo "Then navigate to http://${user}:${pw}@localhost:$port"
+        echo "Then navigate to http://localhost:$port"
         echo
         /usr/src/app/bin/cloudcmd.mjs \
           --port $port \
@@ -39,10 +37,7 @@ jobs:
           --keys-panel \
           --config-dialog \
           --terminal \
-          --no-console \
-          --username "$user" \
-          --password "$pw" \
-          --auth > /dev/null 2>&1
+          --no-console
 
     resource:
       cpu:

--- a/applications/cloudcommander/template.yaml
+++ b/applications/cloudcommander/template.yaml
@@ -1,29 +1,67 @@
 # Copyright 2025 CIQ, Inc. All rights reserved.
+{{- $root := "/fuzzball" }}
 {{- $volumes := splitList "," .Volumes }}
+{{- if eq (len $volumes) 0 }}
+  {{-  fail "At least one volume has to be specified in the Volumes field." }}
+{{- end }}
 
 version: v1
 volumes:
 {{- range $i, $v := $volumes }}
   vol-{{ $i }}:
-    reference: {{$v}}
+  {{- $parts := (splitList ":" $v) }}
+  {{- if eq (len $parts) 2 }}
+    reference: {{ $v }}
+  {{- else if eq (len $parts) 3 }}
+    reference: {{ index $parts 0 }}:{{ index $parts 1 }}
+  {{- else }}
+    {{- fail (printf "Invalid volume reference: %s" $v) }}
+  {{- end }}
 {{- end }}
 jobs:
   cloud-commander:
     image:
       uri: docker://coderaiser/cloudcmd:latest-alpine
-{{- if (trim .Volumes) }}
     mounts:
-  {{- range $i, $v := $volumes }}
+{{- range $i, $v := $volumes }}
+  {{- $parts := splitList ":" $v }}
+  {{- if eq (len $parts) 2 }}
       vol-{{ $i }}:
-        location: /fuzzball/{{ trimPrefix "volume://" $v }}
-  {{- end }}
+        location: {{ $root }}/{{ trimPrefix "volume://" $v }}
+   {{- else }}
+      vol-{{ $i }}:
+        location: {{ $root }}/{{ index $parts 2 | trimPrefix "/" }}
+   {{- end}}
 {{- end }}
+
     cwd: /fuzzball
+    env:
+      - HOME=/tmp/cloudcommander
     command:
       - /bin/sh
       - '-c'
       - |
         port=$(( (RANDOM % 1000) + 8000 ))
+        mkdir -p ${HOME}
+        cat <<__EOF__ > ${HOME}/.cloudcmd.menu.js
+        export default {
+            'R - cd /': async ({CloudCmd}) => {
+                await CloudCmd.changeDir('/');
+            },
+            'X - Exit the File Browser': async ({CloudCmd}) => {
+                const {Dialog, CurrentInfo, TerminalRun} = DOM;
+                const [cancel] = await Dialog.confirm("Exit Cloud Commander?");
+                if (cancel) {
+                    return;
+                }
+                CloudCmd.TerminalRun.show({command: 'bash -c "kill \$(cat ${HOME}/.cloudcmd.pid)"', autoClose: true});
+                setTimeout(() => {
+                    document.body.innerHTML = '<h1>Cloud Commander has exited</h1><p>You can close this tab. The Fuzzball job will end automatically</p>';
+                    document.title = 'Session Ended';
+                    }, 1000);
+            },
+        }
+        __EOF__
         echo
         echo "Access to cloud commander requires port-forwarding via the CLI:"
         echo
@@ -36,8 +74,11 @@ jobs:
           --name "Fuzzball Cloud Commander" \
           --keys-panel \
           --config-dialog \
-          --terminal \
-          --no-console
+          --root {{ $root }} \
+          --terminal &
+        echo $! > ${HOME}/.cloudcmd.pid
+        wait
+        exit 0
 
     resource:
       cpu:

--- a/applications/cloudcommander/template.yaml
+++ b/applications/cloudcommander/template.yaml
@@ -1,0 +1,54 @@
+# Copyright 2025 CIQ, Inc. All rights reserved.
+{{- $volumes := splitList "," .Volumes }}
+
+version: v1
+volumes:
+{{- range $i, $v := $volumes }}
+  vol-{{ $i }}:
+    reference: {{$v}}
+{{- end }}
+jobs:
+  cloud-commander:
+    image:
+      uri: docker://coderaiser/cloudcmd:latest-alpine
+{{- if (trim .Volumes) }}
+    mounts:
+  {{- range $i, $v := $volumes }}
+      vol-{{ $i }}:
+        location: /fuzzball/{{ trimPrefix "volume://" $v }}
+  {{- end }}
+{{- end }}
+    cwd: /fuzzball
+    command:
+      - /bin/sh
+      - '-c'
+      - |
+        port=$(( (RANDOM % 1000) + 8000 ))
+        user="$(cat /dev/urandom | tr -d -c 'a-zA-Z0-9' | head -c10)"
+        pw="$(cat /dev/urandom | tr -d -c 'a-zA-Z0-9' | head -c10)"
+        echo
+        echo "Access cloud commander requires port-forwarding via the CLI:"
+        echo
+        echo "# fuzzball workflow port-forward ${FB_WORKFLOW_ID} cloud-commander $port:$port"
+        echo
+        echo "Then navigate to http://${user}:${pw}@localhost:$port"
+        echo
+        /usr/src/app/bin/cloudcmd.mjs \
+          --port $port \
+          --name "Fuzzball Cloud Commander" \
+          --keys-panel \
+          --config-dialog \
+          --terminal \
+          --no-console \
+          --username "$user" \
+          --password "$pw" \
+          --auth 2>&1 > /dev/null
+
+    resource:
+      cpu:
+        cores: 1
+      memory:
+        size: 6GiB
+    policy:
+      timeout:
+        execute: {{.Timeout}}

--- a/applications/cloudcommander/values.yaml
+++ b/applications/cloudcommander/values.yaml
@@ -1,0 +1,9 @@
+values:
+  - name: "Volumes"
+    display_name: "Comma separated list of volumes to mount"
+    string_value: "volume://user/persistent"
+    display_category: "Storage"
+  - name: "Timeout"
+    display_name: "Execution timeout"
+    string_value: "2h"
+    display_category: "General"

--- a/applications/cloudcommander/values.yaml
+++ b/applications/cloudcommander/values.yaml
@@ -1,7 +1,12 @@
 values:
   - name: "Volumes"
-    display_name: "Comma separated list of volumes to mount"
-    string_value: "volume://user/persistent"
+    display_name: |
+      Comma separated list of volumes to mount. These are Fuzzball volume references
+      such as `volume://user/persistent`. By default the example volume would be available
+      as `user/persistent` in the file browser. If you would like to use a custom path for
+      a particular volume in the file browser, you can specify it like this:
+      `volume://user/persistent:/custom/path`. The leading slash is optional.
+    string_value: "volume://user/persistent:data"
     display_category: "Storage"
   - name: "Timeout"
     display_name: "Execution timeout"


### PR DESCRIPTION
This adds Cloud Commander (https://cloudcmd.io/) as an app to allow easier management of files stored in persistent volumes.
Cloud Commander is MIT-licensed.

Try it out on stable: https://ui.stable.fuzzball.ciq.dev/accounts/b95f6f1b-1c70-491f-b83c-24eb89382f29/applications/7ca1690b-caad-4e42-9f64-815b0d9a70f7 

Video: https://ciqinc.atlassian.net/browse/FUZZ-4724