### PR TITLE
Fix category for transformer fine tuning (#34)

### DIFF
--- a/applications/fine_tuning/metadata.md
+++ b/applications/fine_tuning/metadata.md
@@ -2,7 +2,7 @@
 ---
 id: "transformer_fine_tuning" # needs to be **unique** per application, changing results in a new application
 name: "Transformer Fine Tuning Example"
-category: "AI"
+category: "ML_AND_AI"
 ---
 This workflow demonstrates an example usage pattern to fine tune an existing language model on a new data set. It contains jobs that carry out the following tasks.
 - Downloading and preparing a dataset


### PR DESCRIPTION
- Invalid category "AI" must be "ML_AND_AI"