### PR TITLE
Add Timeout parameter to bases2fastq

### DIFF
--- a/applications/bases2fastq/template.yaml
+++ b/applications/bases2fastq/template.yaml
@@ -55,6 +55,9 @@ jobs:
         threads: true
       memory:
         size: {{ .Memory }}
+    policy:
+      timeout:
+        execute: {{ .Timeout }}
     mounts:
       scratch:
         location: {{ $scratch_mount }}

--- a/applications/bases2fastq/values.yaml
+++ b/applications/bases2fastq/values.yaml
@@ -71,3 +71,7 @@ values:
     display_name: Amount of memory to allocate for bases2fastq.
     string_value: 30GiB
     display_category: Resources
+  - name: Timeout
+    display_name: Maximum runtime of the bases2fastq job.
+    string_value: 6h
+    display_category: Resources


### PR DESCRIPTION
This template should have had a timeout parameter. I will make checking for this part of the review of all the workflows when i get back. Maybe even write a script to to some basic checking.