### PR TITLE
Add rclone server to allow access to data in fuzzball via webdav and sftp

### DIFF
--- a/applications/rclone-server/metadata.md
+++ b/applications/rclone-server/metadata.md
@@ -1,0 +1,27 @@
+# Copyright 2025 CIQ, Inc. All rights reserved.
+---
+id: "rclone-server"
+name: "Rclone server for data management"
+category: "UTILITIES"
+---
+
+This application will start an [Rclone](https://rclone.org/) WebDAV or SFTP
+server that serves data from the mounted Fuzzball volumes and allows you to
+access, browse, upload, and download files from your Fuzzball persistent storage
+volumes using any compatible client.
+
+The server runs on the specified port (default 8080).
+
+To access the server, you'll need to use port-forwarding:
+```
+fuzzball workflow port-forward <workflow-id> <protocol> <port>:<port>
+```
+
+The full command will be included in the log for convenient copy-and-paste.
+
+Then you can connect to the port on localhost with your client of choice.
+
+Notes:
+- Transfer speeds may not be optimal for very large transfers.
+- The server job will run until it hits the timeout or you terminate it
+  manually.

--- a/applications/rclone-server/template.yaml
+++ b/applications/rclone-server/template.yaml
@@ -1,0 +1,78 @@
+# Copyright 2025 CIQ, Inc. All rights reserved.
+{{- $root := "/fuzzball" }}
+{{- $volumes := splitList "," .Volumes }}
+{{- if eq (len $volumes) 0 }}
+  {{-  fail "At least one volume has to be specified in the Volumes field." }}
+{{- end }}
+{{- $username := trim .Username }}
+{{- $password := trim .Password }}
+{{- $protocol := trim .Protocol }}
+
+version: v1
+volumes:
+{{- range $i, $v := $volumes }}
+  vol-{{ $i }}:
+  {{- $parts := (splitList ":" $v) }}
+  {{- if eq (len $parts) 2 }}
+    reference: {{ $v }}
+  {{- else if eq (len $parts) 3 }}
+    reference: {{ index $parts 0 }}:{{ index $parts 1 }}
+  {{- else }}
+    {{- fail (printf "Invalid volume reference: %s" $v) }}
+  {{- end }}
+{{- end }}
+jobs:
+  {{ $protocol }}:
+    image:
+      uri: docker://rclone/rclone:latest
+    mounts:
+{{- range $i, $v := $volumes }}
+  {{- $parts := splitList ":" $v }}
+  {{- if eq (len $parts) 2 }}
+      vol-{{ $i }}:
+        location: {{ $root }}/{{ trimPrefix "volume://" $v }}
+   {{- else }}
+      vol-{{ $i }}:
+        location: {{ $root }}/{{ index $parts 2 | trimPrefix "/" }}
+   {{- end}}
+{{- end }}
+
+    cwd: {{ $root }}
+{{- if (and $username $password) }}
+    env:
+      - RCLONE_USER={{ $username }}
+      - RCLONE_PASS={{ $password }}
+{{- else }}
+  {{- fail "Username and password are required" }}
+{{- end }}
+    script: |
+      #!/bin/sh
+      cat <<__EOF__
+      Access to the {{ .Protocol }} server requires port-forwarding via the CLI:
+        # fuzzball workflow port-forward ${FB_WORKFLOW_ID} {{ .Protocol }} {{ .Port }}:{{ .Port }}
+      In your client program of choice use 'localhost' as the host and {{ .Port }} as the port
+      --------------------------------------------------------------------------------------------
+      __EOF__
+{{- if eq $protocol "sftp" }}
+      rclone serve sftp \
+        --addr localhost:{{ .Port }} \
+        --cache-dir "$(mktemp -d)" \
+        --log-level INFO \
+        {{ $root }}
+{{- else if eq $protocol "webdav" }}
+      rclone serve webdav \
+        --addr localhost:{{ .Port }} \
+        --cache-dir "$(mktemp -d)" \
+        --log-level INFO \
+        {{ $root }}
+{{- else }}
+  {{- fail "only sftp and webdav protocols are supported" }}
+{{- end }}
+    resource:
+      cpu:
+        cores: 2
+      memory:
+        size: 6GiB
+    policy:
+      timeout:
+        execute: {{.Timeout}}

--- a/applications/rclone-server/values.yaml
+++ b/applications/rclone-server/values.yaml
@@ -1,0 +1,39 @@
+values:
+  - name: Container
+    display_name: RClone container to use
+    string_value: docker://rclone/rclone:1.70.3
+    display_category: Container
+
+  - name: Volumes
+    display_name: |
+      Comma separated list of volumes to mount. These are Fuzzball volume references
+      such as `volume://user/persistent`. By default the example volume would be available
+      as `fuzzball/persistent` in WebDAV. If you would like to use a custom path for
+      a particular volume, you can specify it like this:
+      `volume://user/persistent:/custom/path`. The leading slash is optional.
+    string_value: "volume://user/persistent:data"
+    display_category: Storage
+
+  - name: Protocol
+    display_name: |
+      Protocol to serve data with. Currently webdav and sftp are supported
+    string_value: sftp
+    display_category: Protocol
+
+  - name: Port
+    display_name: Server Port to serve the selected protocol on
+    uint_value: 8080
+    display_category: Network
+  - name: Username
+    display_name: Login username
+    string_value: ""
+    display_category: Authentication
+  - name: Password
+    display_name: Login password
+    string_value: ""
+    display_category: Authentication
+
+  - name: Timeout
+    display_name: Execution timeout
+    string_value: 2h
+    display_category: General


### PR DESCRIPTION
There may be other (more performant?) tools around that would achieve the same but this is pretty simple. I will look into others.

WebDAV tends to be faster on downloads (~20MB/s vs 12-15MB/s against stable) and both are slow on uploads (1.2-1.5MB/s against stable). Still useful for smaller amounts of data. Both used cyberduck as the local client

I verified uploads and downloads up to 5.3GB so it definitively does not run into timeouts which makes sense because they used more sane chunked transfers.