### PR TITLE
Refresh ldconfig for /gpu-libs in ollama

### DIFF
--- a/applications/open-webui/template.yaml
+++ b/applications/open-webui/template.yaml
@@ -42,6 +42,12 @@ services:
       #!/bin/bash
       set -e
 
+      # Update ldconfig to know about gpu-libs
+      echo "/gpu-libs" > /etc/ld.so.conf.d/gpu-libs.conf
+      ldconfig
+      echo "ldconfig updated:"
+      ldconfig -p | grep -E 'libcuda|libnvidia' | head -10
+
       echo "Starting Ollama Service"
       echo "NVIDIA Driver Version: $(nvidia-smi --query-gpu=driver_version --format=csv,noheader || echo 'No GPU detected')"
       echo ""


### PR DESCRIPTION
Ollama wasn't picking up /gpu-libs correctly. Running ldconfig updates the cache before starting ollama.