### PR TITLE
chore(ci): bump GitHub Actions off Node 20 runtimes

### DIFF
--- a/.github/workflows/build-containers.yaml
+++ b/.github/workflows/build-containers.yaml
@@ -79,7 +79,7 @@ jobs:
       pr_number: ${{ steps.set-matrix.outputs.pr_number }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
 
@@ -222,7 +222,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Set up Apptainer
         uses: eWaterCycle/setup-apptainer@4bb22c52d4f63406c49e94c804632975787312b3  # v2


### PR DESCRIPTION
## Summary

Node 20 reached EOL on 2026-04-30. This PR bumps GitHub Actions to current stable releases, pinned by full commit SHA with the target tag in a trailing comment.


## Changes

| Action | Before | After |
|---|---|---|
| `actions/checkout` | `v4` | `v6.0.2` |

Files touched: **1** workflow file(s), **2** line change(s).

## Test plan

- [ ] Existing CI runs on this PR and stays green.
- [ ] If this repo's workflows aren't PR-triggered, dispatch them manually after merge or via `workflow_dispatch`.

---

Part of an org-wide bulk update across ~135 ctrliq repos to escape Node 20 EOL.
