### PR TITLE
chore(ci): bump GitHub Actions off Node 20 runtimes (#97)

### DIFF
--- a/.github/workflows/build-containers.yaml
+++ b/.github/workflows/build-containers.yaml
@@ -79,7 +79,7 @@ jobs:
       pr_number: ${{ steps.set-matrix.outputs.pr_number }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
 
@@ -222,7 +222,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Set up Apptainer
         uses: eWaterCycle/setup-apptainer@4bb22c52d4f63406c49e94c804632975787312b3  # v2


### PR DESCRIPTION
Backports PR #97 to v3.3 (Node 20 reached EOL on 2026-04-30. Pin all first- and third-party GitHub Actions to current stable releases by full commit SHA, with the target tag in a trailing comment.)
