### PR TITLE
Improvements to VDI workflow from training prep

### DIFF
--- a/applications/vdi_example/definition_files/vnc.def
+++ b/applications/vdi_example/definition_files/vnc.def
@@ -1,4 +1,4 @@
-# tag: 1.3-1
+# tag: 1.4-1
 
 Bootstrap: docker
 From: rockylinux/rockylinux:9
@@ -128,19 +128,25 @@ cat >/etc/xdg/xfce4/xfconf/xfce-perchannel-xml/xfce4-desktop.xml <<__EOF__
 __EOF__
 
 # make novnc default to using remote resize
-sed -E "s/UI.initSetting\('resize',[[:space:]]*'off'\)/UI.initSetting('resize', 'remote')/" \
-  /usr/share/novnc/app/ui.js > /tmp/ui.js && mv /tmp/ui.js /usr/share/novnc/app/ui.js
+sed -i -E "s/UI.initSetting\('resize',[[:space:]]*'off'\)/UI.initSetting('resize', 'remote')/" \
+  /usr/share/novnc/app/ui.js
 
+# Move TurboVNC's runtime state off $HOME so a persistent home volume can be
+# mounted on $HOME without colliding with vncserver's strict type/ownership
+# check on $HOME/.vnc (which fails on persistent volume backends that don't
+# present the on-disk uid as the running uid). Putting vncUserDir under
+# /tmp/ also relocates the Xauthority file there (see the
+# $vncUserDirUnderTmp branch in /opt/TurboVNC/bin/vncserver).
+cat >/etc/turbovncserver.conf <<'__EOF__'
+$vncUserDir = "/tmp/vnc";
+__EOF__
 
 # script used by workflow
 cat >/usr/local/bin/start-vncserver.sh <<'__EOF__'
 #!/bin/sh
-(
-mkdir -p "${HOME}/.vnc"
-chown -R $(whoami) "${HOME}/.vnc"
-chmod 700 "${HOME}/.vnc"
-) >/dev/null 2>&1
-umask 007
+umask 077
+mkdir -p /tmp/vnc
+chmod 700 /tmp/vnc
 export USER=$(whoami)
 
 /usr/bin/novnc_proxy --vnc localhost:5900 --listen ${1:-6080} &

--- a/applications/vdi_example/template.yaml
+++ b/applications/vdi_example/template.yaml
@@ -66,6 +66,8 @@ services:
       uri: {{ .Container }}
     script: |
       #!/bin/sh
+      mkdir -p "${HOME}"
+      cd "${HOME}"
       echo "Starting desktop and vnc"
       /usr/local/bin/start-vncserver.sh {{ $port }}
     resource:

--- a/applications/vdi_example/values.yaml
+++ b/applications/vdi_example/values.yaml
@@ -1,7 +1,7 @@
 values:
   - name: "Container"
     display_name: Desktop container to use. Has to be compatible with this application
-    string_value: oras://ghcr.io/ctrliq/ciq-fuzzball-catalog/vdi_example-vnc:1.3-1-amd64
+    string_value: oras://ghcr.io/ctrliq/ciq-fuzzball-catalog/vdi_example-vnc:1.4-1-amd64
     display_category: "Container"
   - name: "Cores"
     display_name: "How many CPU cores to allocate."


### PR DESCRIPTION
- relocate TurboVNC runtime state to /tmp/vnc; cwd to $HOME when home volume is mounted
- Update start-vncserver.sh to create /tmp/vnc with mode 0700 via umask 077 + chmod, dropping the silenced subshell so errors bubble.
- Switch the noVNC remote-resize patch from `sed > tmp && mv` to `sed -i` (GNU sed supports it; the temp-file pattern was only needed on BSD sed).
- In template.yaml, set `cwd: {{ $home }}` when HomeVolume is supplied, so terminals opened from the desktop start in the user's home directory. Gated on HomeVolume because the no-volume code path resolves $home to /tmp/homefb, which isn't created at container start.

---

TurboVNC's vncserver does an lstat-based type/ownership check on $HOME/.vnc and fails with "Wrong type or access mode" on volume backends whose on-disk uid doesn't match the running uid. That makes the catalog template's HomeVolume code path (mount a persistent volume on $HOME) unusable on those backends.

Move vncUserDir off $HOME via /etc/turbovncserver.conf so the runtime state ($HOME/.vnc and the Xauthority file, per vncserver's $vncUserDirUnderTmp branch) lives on tmpfs at /tmp/vnc. The persistent home volume now holds only user-owned content (dotfiles, notebooks, etc.), which is what trainees and template users actually want from "persistent home."
