### PR TITLE
Using host network for services accessed by other jobs/services

### DIFF
--- a/applications/llm_client_server/template.yaml
+++ b/applications/llm_client_server/template.yaml
@@ -18,6 +18,7 @@ volumes:
 services:
   vllm:
     network:
+      host: true
       ports:
         - name: openai-api
           port: {{ $vllm_api_port }}

--- a/applications/nim_flux_webui/template.yaml
+++ b/applications/nim_flux_webui/template.yaml
@@ -68,6 +68,7 @@ services:
         nvidia.com/gpu.model: "{{ trim .GPUModel }}"
       {{- end }}
     network:
+      host: true
       ports:
         - name: http
           port: {{ $nim_port }}
@@ -189,6 +190,7 @@ services:
         status: RUNNING
         description: stub proxies to NIM so NIM must be ready first
     network:
+      host: true
       ports:
         - name: http
           port: {{ $stub_port }}

--- a/applications/open-webui/template.yaml
+++ b/applications/open-webui/template.yaml
@@ -89,6 +89,7 @@ services:
       wait $OLLAMA_PID
 
     network:
+      host: true
       ports:
         - name: api
           port: 11434
@@ -149,6 +150,7 @@ services:
         volume: data
 
     network:
+      host: true
       ports:
         - name: web
           port: 8080


### PR DESCRIPTION
in the same workflow.

This prevents the use of port randomization introduced in FUZZ-8033 for services accessed by other services in the same workflow. If we make the random ports more easily discoverable we may revisit this.