### PR TITLE
FUZZ-8343: LiteLLM gateway catalog entry

### DIFF
--- a/applications/litellm/metadata.md
+++ b/applications/litellm/metadata.md
@@ -33,8 +33,9 @@ Every call to the gateway carries two credentials: a Fuzzball token in `Authoriz
    fuzzball workflow endpoints list
    ```
 
-2. Get the master key. It is generated at submit time; the `show-gateway` job prints it,
-   and it is in the workflow definition via `fuzzball workflow get <workflow>`.
+2. Get the master key. It is generated at submit time; read it with
+   `fuzzball workflow log <workflow> show-gateway`, or from the workflow definition via
+   `fuzzball workflow get <workflow>`.
 
 3. Get a Fuzzball token: your own user token works, or mint one bound to the gateway's
    endpoint with `fuzzball workflow endpoints generate-token <endpoint id>`.
@@ -73,13 +74,21 @@ annotations:
 ```
 
 `ciq.com/model` is the name callers ask for, and it must match the name the server serves
-under (for vLLM, `--served-model-name`). Set `per-replica: true` on the endpoint to let the
-gateway balance across replicas itself, and a `scale-down.drain-period` comfortably above
-the gateway's refresh interval so a retiring replica leaves the rotation before it stops.
+under (for vLLM, `--served-model-name`). The endpoint must not be `public`: the gateway
+authenticates to models with minted endpoint tokens, and tokens cannot be minted for
+public endpoints. Set `per-replica: true` (which requires `type: subdomain` and an
+autoscaler on the service) to let the gateway balance across replicas itself, and an
+`autoscaler.scale-down.drain-period` comfortably above the gateway's refresh interval
+(`RefreshInterval`, default 25s) so a retiring replica leaves the rotation before it
+stops.
 
 Do not set an API key on the served model. Fuzzball's proxy consumes the `Authorization`
 header on a non-public endpoint, so the model server never sees one -- the endpoint's own
-scope is the access control.
+scope is the access control. A model server in the same workflow as the gateway is always
+skipped: the gateway only serves other workflows' endpoints.
+
+To confirm a model was picked up, watch `fuzzball workflow log <workflow> gateway` for a
+`REGISTERED` line on the next discovery pass, or list `/v1/models`.
 
 ## Things to know before you start it
 
@@ -96,11 +105,13 @@ scope is the access control.
 - **A pool that scales to zero surfaces LiteLLM's router cooldown to callers.** Such a
   model has a single LiteLLM deployment, so each drain produces a short burst of 429
   "No deployments available" responses until the next discovery pass swaps the route.
-  Clients should retry on 429; `cooldown_time` and `allowed_fails` in
-  `router_settings` are the tuning knobs if the bursts matter.
-- **Generation length is bounded by the cluster's endpoint ingress timeout.** A response
-  that produces nothing for longer than that window is cut off. Ask your cluster
-  administrator what it is set to.
+  Clients should retry on 429. Tuning the router's cooldown means adding a LiteLLM config
+  file to a copy of this entry; it is not exposed as a value.
+- **Generation length is bounded by the endpoint proxy's 10-minute idle timeout.** A
+  response that produces nothing for longer than that window is cut off.
+- **Callers borrow the owner's reach.** The gateway discovers and authenticates to models
+  as the identity that started it, so the gateway's endpoint scope (`ServiceScope`)
+  decides who can use every model it serves -- regardless of the callers' own grants.
 - **Anyone who can read the workflow can read the master key.** It is generated fresh on
   every workflow start and embedded in the workflow definition. Hand callers virtual keys,
   never the master key.

--- a/applications/litellm/metadata.md
+++ b/applications/litellm/metadata.md
@@ -24,19 +24,42 @@ Python, meant to be copied as the starting point for your own gateway.
 
 ## Using it
 
-Create a virtual key against the gateway, then point any OpenAI client at the endpoint
-URL. Callers send two credentials: the Fuzzball endpoint token in `Authorization`, and the
-LiteLLM virtual key in `x-litellm-api-key`.
+Every call to the gateway carries two credentials: a Fuzzball token in `Authorization`
+(the endpoint's scope is the access control), and a LiteLLM key in `x-litellm-api-key`.
 
-```sh
-curl -H "Authorization: Bearer ${FUZZBALL_ENDPOINT_TOKEN}" \
-     -H "x-litellm-api-key: ${VIRTUAL_KEY}" \
-     -H "Content-Type: application/json" \
-     "${GATEWAY_URL}v1/chat/completions" \
-     -d '{"model": "<alias>", "messages": [{"role": "user", "content": "hello"}]}'
-```
+1. Get the gateway URL:
 
-`GET /v1/models` lists whatever the gateway has discovered.
+   ```sh
+   fuzzball workflow endpoints list
+   ```
+
+2. Get the master key. It is generated at submit time; the `show-gateway` job prints it,
+   and it is in the workflow definition via `fuzzball workflow get <workflow>`.
+
+3. Get a Fuzzball token: your own user token works, or mint one bound to the gateway's
+   endpoint with `fuzzball workflow endpoints generate-token <endpoint id>`.
+
+4. Mint a virtual key for each caller, so the master key never leaves the operator:
+
+   ```sh
+   curl -X POST \
+        -H "Authorization: Bearer ${FUZZBALL_TOKEN}" \
+        -H "x-litellm-api-key: ${MASTER_KEY}" \
+        -H "Content-Type: application/json" \
+        "${GATEWAY_URL}/key/generate" -d '{"models": []}'
+   ```
+
+5. Point any OpenAI client at the gateway with the virtual key:
+
+   ```sh
+   curl -H "Authorization: Bearer ${FUZZBALL_TOKEN}" \
+        -H "x-litellm-api-key: ${VIRTUAL_KEY}" \
+        -H "Content-Type: application/json" \
+        "${GATEWAY_URL}/v1/chat/completions" \
+        -d '{"model": "<alias>", "messages": [{"role": "user", "content": "hello"}]}'
+   ```
+
+`GET /v1/models` (same two credentials) lists whatever the gateway has discovered.
 
 ## Publishing a model to it
 
@@ -62,11 +85,11 @@ scope is the access control.
 
 - **The database is pinned to the LiteLLM version.** A different LiteLLM release reading
   another release's schema accepts writes and then never routes the model. Changing
-  `litellm-version` means starting with a fresh database.
+  `LiteLLMVersion` means starting with a fresh database.
 - **The default volume is ephemeral**, so virtual keys, budgets and spend history are lost
-  when the workflow stops. Point `data-volume` at a persistent volume for anything you rely
+  when the workflow stops. Point `DataVolume` at a persistent volume for anything you rely
   on.
-- **`cluster-ca-secret` is effectively required on a cluster whose API is served with a
+- **`ClusterCASecret` is effectively required on a cluster whose API is served with a
   private CA.** Without it discovery never reaches the Fuzzball API: the gateway serves no
   models at all and only logs `DISCOVERY-FAILED` SSL errors, while the workflow itself looks
   healthy.
@@ -78,4 +101,6 @@ scope is the access control.
 - **Generation length is bounded by the cluster's endpoint ingress timeout.** A response
   that produces nothing for longer than that window is cut off. Ask your cluster
   administrator what it is set to.
-- The master key must live in a **user-scoped** secret (`secret://user/...`).
+- **Anyone who can read the workflow can read the master key.** It is generated fresh on
+  every workflow start and embedded in the workflow definition. Hand callers virtual keys,
+  never the master key.

--- a/applications/litellm/metadata.md
+++ b/applications/litellm/metadata.md
@@ -62,11 +62,11 @@ scope is the access control.
 
 - **The database is pinned to the LiteLLM version.** A different LiteLLM release reading
   another release's schema accepts writes and then never routes the model. Changing
-  `LiteLLMVersion` means starting with a fresh database.
+  `litellm-version` means starting with a fresh database.
 - **The default volume is ephemeral**, so virtual keys, budgets and spend history are lost
-  when the workflow stops. Point `DataVolume` at a persistent volume for anything you rely
+  when the workflow stops. Point `data-volume` at a persistent volume for anything you rely
   on.
-- **`ClusterCASecret` is effectively required on a cluster whose API is served with a
+- **`cluster-ca-secret` is effectively required on a cluster whose API is served with a
   private CA.** Without it discovery never reaches the Fuzzball API: the gateway serves no
   models at all and only logs `DISCOVERY-FAILED` SSL errors, while the workflow itself looks
   healthy.

--- a/applications/litellm/metadata.md
+++ b/applications/litellm/metadata.md
@@ -1,0 +1,73 @@
+# Copyright 2026 CIQ, Inc. All rights reserved.
+---
+id: "ciq/ml_and_ai/litellm_gateway"
+name: "LiteLLM Model Gateway"
+category: "ML_AND_AI"
+tags:
+- LLM
+- gateway
+- OpenAI
+- inference
+- genAI
+---
+One OpenAI-compatible base URL in front of every model-serving workflow your identity can
+reach. Agents and IDE plugins ask for a model by name; which workflow serves it, and how
+many replicas it has, stays invisible to them.
+
+The gateway configures itself. It polls the Fuzzball endpoints API, keeps the endpoints
+annotated `ciq.com/api: openai`, and registers one LiteLLM deployment per live replica --
+so a pool scaling up or down is reflected without anyone touching the gateway. A request
+for a model whose pool has scaled to zero wakes it and succeeds on retry.
+
+## Using it
+
+Create a virtual key against the gateway, then point any OpenAI client at the endpoint
+URL. Callers send two credentials: the Fuzzball endpoint token in `Authorization`, and the
+LiteLLM virtual key in `x-litellm-api-key`.
+
+```sh
+curl -H "Authorization: Bearer ${FUZZBALL_ENDPOINT_TOKEN}" \
+     -H "x-litellm-api-key: ${VIRTUAL_KEY}" \
+     -H "Content-Type: application/json" \
+     "${GATEWAY_URL}v1/chat/completions" \
+     -d '{"model": "<alias>", "messages": [{"role": "user", "content": "hello"}]}'
+```
+
+`GET /v1/models` lists whatever the gateway has discovered.
+
+## Publishing a model to it
+
+Any workflow can advertise itself by annotating a service endpoint. The gateway reads two
+keys and ignores every endpoint that does not carry them, including its own:
+
+```yaml
+annotations:
+  ciq.com/api: openai
+  ciq.com/model: llama-3.3-70b
+```
+
+`ciq.com/model` is the name callers ask for, and it must match the name the server serves
+under (for vLLM, `--served-model-name`). Set `per-replica: true` on the endpoint to let the
+gateway balance across replicas itself, and a `scale-down.drain-period` comfortably above
+the gateway's refresh interval so a retiring replica leaves the rotation before it stops.
+
+Do not set an API key on the served model. Fuzzball's proxy consumes the `Authorization`
+header on a non-public endpoint, so the model server never sees one -- the endpoint's own
+scope is the access control.
+
+## Things to know before you start it
+
+- **The database is pinned to the LiteLLM version.** A different LiteLLM release reading
+  another release's schema accepts writes and then never routes the model. Changing
+  `LiteLLMVersion` means starting with a fresh database.
+- **The default volume is ephemeral**, so virtual keys, budgets and spend history are lost
+  when the workflow stops. Point `DataVolume` at a persistent volume for anything you rely
+  on.
+- **`ClusterCASecret` is effectively required on a cluster whose API is served with a
+  private CA.** Without it discovery never reaches the Fuzzball API: the gateway serves no
+  models at all and only logs `DISCOVERY-FAILED` SSL errors, while the workflow itself looks
+  healthy.
+- **Generation length is bounded by the cluster's endpoint ingress timeout.** A response
+  that produces nothing for longer than that window is cut off. Ask your cluster
+  administrator what it is set to.
+- The master key must live in a **user-scoped** secret (`secret://user/...`).

--- a/applications/litellm/metadata.md
+++ b/applications/litellm/metadata.md
@@ -19,6 +19,9 @@ annotated `ciq.com/api: openai`, and registers one LiteLLM deployment per live r
 so a pool scaling up or down is reflected without anyone touching the gateway. A request
 for a model whose pool has scaled to zero wakes it and succeeds on retry.
 
+This entry is a reference implementation: the reconcile loop is deliberately plain
+Python, meant to be copied as the starting point for your own gateway.
+
 ## Using it
 
 Create a virtual key against the gateway, then point any OpenAI client at the endpoint
@@ -67,6 +70,11 @@ scope is the access control.
   private CA.** Without it discovery never reaches the Fuzzball API: the gateway serves no
   models at all and only logs `DISCOVERY-FAILED` SSL errors, while the workflow itself looks
   healthy.
+- **A pool that scales to zero surfaces LiteLLM's router cooldown to callers.** Such a
+  model has a single LiteLLM deployment, so each drain produces a short burst of 429
+  "No deployments available" responses until the next discovery pass swaps the route.
+  Clients should retry on 429; `cooldown_time` and `allowed_fails` in
+  `router_settings` are the tuning knobs if the bursts matter.
 - **Generation length is bounded by the cluster's endpoint ingress timeout.** A response
   that produces nothing for longer than that window is cut off. Ask your cluster
   administrator what it is set to.

--- a/applications/litellm/template.yaml
+++ b/applications/litellm/template.yaml
@@ -5,6 +5,10 @@
 {{- fail "MasterKeySecret is required: store the LiteLLM master key (sk-...) in a user-scoped secret and pass its reference, e.g. secret://user/litellm-master" }}
 {{- end }}
 {{- $clusterCA := trim .ClusterCASecret }}
+{{- $dbPassword := trim .DatabasePasswordSecret }}
+{{- if not $dbPassword }}
+{{- $dbPassword = "litellm" }}
+{{- end }}
 {{- $dbPort := randInt 10000 17000 }}
 {{- $llmPort := randInt 17000 24000 }}
 {{- $dbUser := "litellm" }}
@@ -29,7 +33,7 @@ services:
     command: ["docker-entrypoint.sh", "postgres", "-p", "{{ $dbPort }}"]
     env:
       - POSTGRES_USER={{ $dbUser }}
-      - POSTGRES_PASSWORD={{ $dbUser }}
+      - POSTGRES_PASSWORD={{ $dbPassword }}
       - POSTGRES_DB={{ $dbName }}
     mounts:
       {{ $dbMount }}:
@@ -58,7 +62,7 @@ services:
       uri: docker://ghcr.io/berriai/litellm-database:{{ .LiteLLMVersion }}
     env:
       - STORE_MODEL_IN_DB=True
-      - DATABASE_URL=postgresql://{{ $dbUser }}:{{ $dbUser }}@database.svc:{{ $dbPort }}/{{ $dbName }}
+      - DB_PASSWORD={{ $dbPassword }}
       - LITELLM_MASTER_KEY={{ $masterKey }}
       - LITELLM_LOG=INFO
       - SSL_CERT_FILE={{ $caBundle }}
@@ -91,6 +95,10 @@ services:
           scope: {{ .ServiceScope }}
     script: |
       #!/bin/bash
+      set -e
+      # The password may come from a secret, which the platform only substitutes
+      # as a whole env value -- so the URL is composed here rather than templated.
+      export DATABASE_URL="postgresql://{{ $dbUser }}:${DB_PASSWORD}@database.svc:{{ $dbPort }}/{{ $dbName }}"
       # Prisma's query engines were cached under the image user's HOME. Fuzzball
       # runs the container under a different uid, so without this LiteLLM's schema
       # push tries to re-download them.

--- a/applications/litellm/template.yaml
+++ b/applications/litellm/template.yaml
@@ -1,11 +1,11 @@
 # Copyright 2026 CIQ, Inc. All rights reserved.
 
-{{- $masterKey := trim .MasterKeySecret }}
+{{- $masterKey := trim (index . "master-key-secret") }}
 {{- if not $masterKey }}
-{{- fail "MasterKeySecret is required: store the LiteLLM master key (sk-...) in a user-scoped secret and pass its reference, e.g. secret://user/litellm-master" }}
+{{- fail "master-key-secret is required: store the LiteLLM master key (sk-...) in a user-scoped secret and pass its reference, e.g. secret://user/litellm-master" }}
 {{- end }}
-{{- $clusterCA := trim .ClusterCASecret }}
-{{- $dbPassword := trim .DatabasePasswordSecret }}
+{{- $clusterCA := trim (index . "cluster-ca-secret") }}
+{{- $dbPassword := trim (index . "database-password-secret") }}
 {{- if not $dbPassword }}
 {{- $dbPassword = "litellm" }}
 {{- end }}
@@ -20,7 +20,7 @@ version: v4
 
 volumes:
   db:
-    reference: {{ .DataVolume }}
+    reference: {{ index . "data-volume" }}
 
 services:
   # The gateway's state -- virtual keys, per-team budgets, spend history, and the
@@ -29,7 +29,7 @@ services:
   # versions: a mismatched release accepts writes and then never routes the model.
   database:
     image:
-      uri: docker://postgres:{{ .PostgresVersion }}
+      uri: docker://postgres:{{ index . "postgres-version" }}
     command: ["docker-entrypoint.sh", "postgres", "-p", "{{ $dbPort }}"]
     env:
       - POSTGRES_USER={{ $dbUser }}
@@ -53,13 +53,13 @@ services:
       failure-threshold: 60
     resource:
       cpu:
-        cores: {{ .DatabaseCores }}
+        cores: {{ index . "database-cores" }}
       memory:
-        size: {{ .DatabaseMemory }}
+        size: {{ index . "database-memory" }}
 
   gateway:
     image:
-      uri: docker://ghcr.io/berriai/litellm-database:{{ .LiteLLMVersion }}
+      uri: docker://ghcr.io/berriai/litellm-database:{{ index . "litellm-version" }}
     env:
       - STORE_MODEL_IN_DB=True
       - DB_PASSWORD={{ $dbPassword }}
@@ -67,10 +67,10 @@ services:
       - LITELLM_LOG=INFO
       - SSL_CERT_FILE={{ $caBundle }}
       - LLM_PORT={{ $llmPort }}
-      - DISCOVERY_VALUE={{ .DiscoveryApiValue }}
-      - REFRESH_INTERVAL={{ .RefreshInterval }}
-      - TOKEN_TTL={{ .TokenLifetime }}
-      - COLD_START_RETRIES={{ .ColdStartRetries }}
+      - DISCOVERY_VALUE={{ index . "discovery-api-value" }}
+      - REFRESH_INTERVAL={{ index . "refresh-interval" }}
+      - TOKEN_TTL={{ index . "token-lifetime" }}
+      - COLD_START_RETRIES={{ index . "cold-start-retries" }}
       - FB_CA_BUNDLE={{ $caBundle }}
 {{- if $clusterCA }}
       - CLUSTER_CA_PEM={{ $clusterCA }}
@@ -92,7 +92,7 @@ services:
           port-name: llm
           protocol: http
           type: subdomain
-          scope: {{ .ServiceScope }}
+          scope: {{ .scope }}
     script: |
       #!/bin/bash
       set -e
@@ -313,9 +313,9 @@ services:
       failure-threshold: 60
     resource:
       cpu:
-        cores: {{ .GatewayCores }}
+        cores: {{ index . "gateway-cores" }}
       memory:
-        size: {{ .GatewayMemory }}
+        size: {{ index . "gateway-memory" }}
 
 jobs:
   show-gateway:

--- a/applications/litellm/template.yaml
+++ b/applications/litellm/template.yaml
@@ -1,0 +1,363 @@
+# Copyright 2026 CIQ, Inc. All rights reserved.
+
+{{- $masterKey := trim .MasterKeySecret }}
+{{- if not $masterKey }}
+{{- fail "MasterKeySecret is required: store the LiteLLM master key (sk-...) in a user-scoped secret and pass its reference, e.g. secret://user/litellm-master" }}
+{{- end }}
+{{- $clusterCA := trim .ClusterCASecret }}
+{{- $dbPort := randInt 10000 17000 }}
+{{- $llmPort := randInt 17000 24000 }}
+{{- $dbUser := "litellm" }}
+{{- $dbName := "litellm" }}
+{{- $dbMount := "/var/lib/postgresql/data" }}
+{{- $caBundle := "/tmp/fuzzball-ca.pem" }}
+
+version: v4
+
+volumes:
+  db:
+    reference: {{ .DataVolume }}
+
+services:
+  # The gateway's state -- virtual keys, per-team budgets, spend history, and the
+  # discovered model list -- all live here. LiteLLM applies its own schema at
+  # startup, which is why one database must never be shared across LiteLLM
+  # versions: a mismatched release accepts writes and then never routes the model.
+  database:
+    image:
+      uri: docker://postgres:{{ .PostgresVersion }}
+    command: ["docker-entrypoint.sh", "postgres", "-p", "{{ $dbPort }}"]
+    env:
+      - POSTGRES_USER={{ $dbUser }}
+      - POSTGRES_PASSWORD={{ $dbUser }}
+      - POSTGRES_DB={{ $dbName }}
+    mounts:
+      {{ $dbMount }}:
+        volume: db
+    network:
+      host: true
+      ports:
+        - name: postgres
+          port: {{ $dbPort }}
+          protocol: tcp
+    persist: true
+    readiness-probe:
+      tcp-socket:
+        port: {{ $dbPort }}
+      initial-delay-seconds: 5
+      period-seconds: 5
+      failure-threshold: 60
+    resource:
+      cpu:
+        cores: {{ .DatabaseCores }}
+      memory:
+        size: {{ .DatabaseMemory }}
+
+  gateway:
+    image:
+      uri: docker://ghcr.io/berriai/litellm-database:{{ .LiteLLMVersion }}
+    env:
+      - STORE_MODEL_IN_DB=True
+      - DATABASE_URL=postgresql://{{ $dbUser }}:{{ $dbUser }}@database.svc:{{ $dbPort }}/{{ $dbName }}
+      - LITELLM_MASTER_KEY={{ $masterKey }}
+      - LITELLM_LOG=INFO
+      - SSL_CERT_FILE={{ $caBundle }}
+      - LLM_PORT={{ $llmPort }}
+      - DISCOVERY_VALUE={{ .DiscoveryApiValue }}
+      - REFRESH_INTERVAL={{ .RefreshInterval }}
+      - TOKEN_TTL={{ .TokenLifetime }}
+      - COLD_START_RETRIES={{ .ColdStartRetries }}
+      - FB_CA_BUNDLE={{ $caBundle }}
+{{- if $clusterCA }}
+      - CLUSTER_CA_PEM={{ $clusterCA }}
+{{- end }}
+    depends-on:
+      - name: database
+        status: RUNNING
+        description: "LiteLLM applies its schema at startup"
+    network:
+      host: true
+      ports:
+        - name: llm
+          port: {{ $llmPort }}
+          protocol: tcp
+      endpoints:
+        # No ciq.com/api annotation here on purpose: it is how the gateway
+        # recognises its own endpoint and leaves itself out of its model list.
+        - name: openai
+          port-name: llm
+          protocol: http
+          type: subdomain
+          scope: {{ .ServiceScope }}
+    script: |
+      #!/bin/bash
+      # Prisma's query engines were cached under the image user's HOME. Fuzzball
+      # runs the container under a different uid, so without this LiteLLM's schema
+      # push tries to re-download them.
+      export HOME=/root
+
+      # SSL_CERT_FILE replaces the trust store wholesale rather than adding to it,
+      # so a private cluster CA is appended to the system bundle. Public TLS has
+      # to keep working: LiteLLM reaches real providers and its own engine
+      # downloads over it.
+      if [ -f /etc/ssl/certs/ca-certificates.crt ]; then
+        cp /etc/ssl/certs/ca-certificates.crt {{ $caBundle }}
+      else
+        cp /etc/ssl/cert.pem {{ $caBundle }}
+      fi
+      if [ -n "${CLUSTER_CA_PEM}" ]; then
+        printf '%s\n' "${CLUSTER_CA_PEM}" >> {{ $caBundle }}
+      fi
+
+      cat > /tmp/reconcile.py <<'PYEOF'
+      # Keeps LiteLLM's deployment list equal to the set of annotated endpoints
+      # this workflow's identity can reach. LiteLLM itself is the state of record
+      # (read back through /model/info each pass), so a restart of this loop
+      # cannot lose track of what is registered.
+      import json, os, ssl, threading, time, urllib.error, urllib.request
+
+      API = os.environ["FB_OPENAPI_URL"].rstrip("/")
+      OWN_WORKFLOW = os.environ.get("FB_WORKFLOW_ID", "")
+      MASTER = os.environ["LITELLM_MASTER_KEY"]
+      LLM = "http://127.0.0.1:" + os.environ["LLM_PORT"]
+      WANT_API = os.environ["DISCOVERY_VALUE"]
+      INTERVAL = int(os.environ["REFRESH_INTERVAL"])
+      TTL = int(os.environ["TOKEN_TTL"])
+      RETRIES = int(os.environ["COLD_START_RETRIES"])
+      API_ANNOTATION = "ciq.com/api"
+      MODEL_ANNOTATION = "ciq.com/model"
+
+      CTX = ssl.create_default_context(cafile=os.environ.get("FB_CA_BUNDLE") or None)
+
+      # The workflow token is injected once and expires; a gateway is meant to
+      # outlive it, so it is held in a cell the refresher can replace.
+      TOKEN = [os.environ["FB_TOKEN"]]
+
+      def call(url, token, method="GET", body=None, ctx=None):
+          payload = json.dumps(body).encode() if body is not None else None
+          request = urllib.request.Request(url, method=method, data=payload)
+          request.add_header("Authorization", "Bearer " + token)
+          request.add_header("Content-Type", "application/json")
+          with urllib.request.urlopen(request, context=ctx, timeout=30) as response:
+              raw = response.read()
+          return json.loads(raw) if raw else None
+
+      def refresh_token():
+          # Service tokens last seven days. Renew well inside that, and keep the
+          # old one on failure -- it stays valid until its original expiry.
+          while True:
+              time.sleep(4 * 24 * 3600)
+              try:
+                  fresh = call(API + "/v4/workflows:refreshToken", TOKEN[0],
+                               method="POST", body=dict(), ctx=CTX)
+                  if fresh and fresh.get("token"):
+                      TOKEN[0] = fresh["token"]
+                      print("TOKEN-REFRESHED", flush=True)
+              except Exception as err:
+                  print("TOKEN-REFRESH-FAILED", repr(err), flush=True)
+
+      def list_endpoints():
+          # Every page, or none of them. A truncated walk looks identical to
+          # models having disappeared, and acting on it would deregister live
+          # models, so a failure here propagates and the caller keeps what it has.
+          rows = []
+          page_token = ""
+          while True:
+              url = API + "/v4/endpoints?pageSize=500"
+              if page_token:
+                  url = url + "&pageToken=" + page_token
+              page = call(url, TOKEN[0], ctx=CTX)
+              rows.extend(page.get("endpoints") or [])
+              page_token = page.get("pageToken") or ""
+              if not page_token:
+                  return rows
+
+      def desired(rows):
+          # api_base -> model name and the endpoint id to mint a token against.
+          serving = []
+          for row in rows:
+              annotations = row.get("annotations") or {}
+              if annotations.get(API_ANNOTATION) != WANT_API:
+                  continue
+              if row.get("workflowId") == OWN_WORKFLOW:
+                  continue
+              serving.append(row)
+
+          replicas_of = dict()
+          for row in serving:
+              pool = row.get("poolEndpointId") or ""
+              if pool:
+                  replicas_of.setdefault(pool, []).append(row)
+
+          wanted = dict()
+          for row in serving:
+              # A pool with live per-replica endpoints is addressed one replica at
+              # a time so this gateway does the balancing. Its own endpoint is
+              # registered only while it has no ready replicas, where it is what
+              # turns a request into a wake.
+              if not (row.get("poolEndpointId") or "") and replicas_of.get(row.get("id")):
+                  continue
+              model = (row.get("annotations") or {}).get(MODEL_ANNOTATION)
+              url = row.get("url") or ""
+              if not model or not url:
+                  continue
+              wanted[url.rstrip("/") + "/v1"] = dict(model=model, endpoint=row.get("id"))
+          return wanted
+
+      def registered():
+          # api_base -> the LiteLLM model ids pointing at it.
+          try:
+              info = call(LLM + "/model/info", MASTER)
+          except urllib.error.HTTPError as err:
+              # An empty model table answers 500, not an empty list, and that is
+              # the state the first registration has to run in. Every other error
+              # propagates: reading a broken gateway as empty re-registers models.
+              if err.code == 500 and "LLM Model List not loaded" in err.read().decode("utf-8", "replace"):
+                  return dict()
+              raise
+          current = dict()
+          for entry in info.get("data") or []:
+              params = entry.get("litellm_params") or {}
+              base = params.get("api_base")
+              model_id = (entry.get("model_info") or {}).get("id")
+              if base and model_id:
+                  current.setdefault(base, []).append(model_id)
+          return current
+
+      def register(base, model, endpoint_id):
+          token = call(API + "/v4/endpoints/" + endpoint_id + "/token", TOKEN[0],
+                       method="POST", body=dict(expirationSeconds=TTL), ctx=CTX)
+          params = dict(model="openai/" + model, api_base=base,
+                        api_key=token.get("token"), num_retries=RETRIES)
+          call(LLM + "/model/new", MASTER, method="POST",
+               body=dict(model_name=model, litellm_params=params))
+
+      def deregister(model_id):
+          call(LLM + "/model/delete", MASTER, method="POST", body=dict(id=model_id))
+
+      threading.Thread(target=refresh_token, daemon=True).start()
+
+      minted_at = dict()
+      while True:
+          try:
+              wanted = desired(list_endpoints())
+          except Exception as err:
+              print("DISCOVERY-FAILED keeping current models", repr(err), flush=True)
+              time.sleep(INTERVAL)
+              continue
+          try:
+              current = registered()
+          except Exception as err:
+              print("MODEL-INFO-FAILED", repr(err), flush=True)
+              time.sleep(INTERVAL)
+              continue
+
+          for base, spec in wanted.items():
+              known = base in current
+              expiring = known and time.time() - minted_at.get(base, 0) > TTL / 2
+              if known and not expiring:
+                  continue
+              try:
+                  # Rotation adds the replacement before dropping the original,
+                  # so the model is never left without a route. Both point at the
+                  # same replica, so the momentary duplicate is harmless.
+                  register(base, spec["model"], spec["endpoint"])
+                  minted_at[base] = time.time()
+                  if expiring:
+                      for model_id in current[base]:
+                          deregister(model_id)
+                      print("ROTATED", spec["model"], base, flush=True)
+                  else:
+                      print("REGISTERED", spec["model"], base, flush=True)
+              except Exception as err:
+                  print("REGISTER-FAILED", base, repr(err), flush=True)
+
+          for base, model_ids in current.items():
+              if base in wanted:
+                  continue
+              for model_id in model_ids:
+                  try:
+                      deregister(model_id)
+                      print("REMOVED", base, flush=True)
+                  except Exception as err:
+                      print("REMOVE-FAILED", base, repr(err), flush=True)
+              minted_at.pop(base, None)
+
+          time.sleep(INTERVAL)
+      PYEOF
+
+      litellm --port "${LLM_PORT}" &
+      gateway_pid=$!
+
+      # Discovery only makes sense once the admin API answers, and it must not
+      # outlive the process it configures.
+      python3 /tmp/reconcile.py &
+
+      wait "${gateway_pid}"
+    persist: true
+    readiness-probe:
+      http-get:
+        path: /health/liveliness
+        port: {{ $llmPort }}
+      initial-delay-seconds: 20
+      period-seconds: 10
+      timeout-seconds: 5
+      failure-threshold: 60
+    resource:
+      cpu:
+        cores: {{ .GatewayCores }}
+      memory:
+        size: {{ .GatewayMemory }}
+
+jobs:
+  show-gateway:
+    image:
+      uri: docker://curlimages/curl:8.17.0
+    env:
+      - GATEWAY=http://gateway.svc:{{ $llmPort }}
+      - MASTER_KEY={{ $masterKey }}
+    depends-on:
+      - name: gateway
+        status: RUNNING
+        description: "Wait for the gateway to answer"
+    script: |
+      #!/bin/sh
+      set -e
+
+      echo "Get the gateway base URL with:"
+      echo "   fuzzball workflow endpoints list"
+      echo ""
+
+      echo "Models discovered so far:"
+      curl -sf -H "Authorization: Bearer ${MASTER_KEY}" "${GATEWAY}/v1/models" || \
+        echo "   (none yet -- annotate a model endpoint with ciq.com/api and ciq.com/model)"
+      echo ""
+
+      echo "Every call through the endpoint carries two credentials: a Fuzzball"
+      echo "credential in Authorization, and a LiteLLM key in x-litellm-api-key."
+      echo ""
+      echo "Create a virtual key:"
+      echo "   curl -X POST \\"
+      echo "     -H \"Authorization: Bearer <fuzzball token>\" \\"
+      echo "     -H \"x-litellm-api-key: <master key>\" \\"
+      echo "     -H \"Content-Type: application/json\" \\"
+      echo "     <gateway url>key/generate -d '{\"models\": []}'"
+      echo ""
+      echo "Then call the gateway with:"
+      echo "   Authorization: Bearer <fuzzball token>"
+      echo "   x-litellm-api-key: <virtual key>"
+      echo ""
+      echo "A Fuzzball token is your user token, or an endpoint token from:"
+      echo "   fuzzball workflow endpoints generate-token <endpoint id>"
+      echo ""
+      echo "The gateway runs until the workflow is cancelled."
+    resource:
+      cpu:
+        cores: 1
+      memory:
+        size: 128MB
+    policy:
+      timeout:
+        execute: 10m
+
+defaults: {}

--- a/applications/litellm/template.yaml
+++ b/applications/litellm/template.yaml
@@ -1,14 +1,11 @@
 # Copyright 2026 CIQ, Inc. All rights reserved.
 
-{{- $masterKey := trim (index . "master-key-secret") }}
-{{- if not $masterKey }}
-{{- fail "master-key-secret is required: store the LiteLLM master key (sk-...) in a user-scoped secret and pass its reference, e.g. secret://user/litellm-master" }}
-{{- end }}
-{{- $clusterCA := trim (index . "cluster-ca-secret") }}
-{{- $dbPassword := trim (index . "database-password-secret") }}
-{{- if not $dbPassword }}
-{{- $dbPassword = "litellm" }}
-{{- end }}
+{{- /* Both credentials are generated at submit time and live in the rendered
+       definition; the show-gateway job prints the master key. slim-sprig has
+       no randAlphaNum, so they are built as hex from 63-bit randInt draws. */}}
+{{- $masterKey := printf "sk-%016x%016x" (randInt 0 9223372036854775807) (randInt 0 9223372036854775807) }}
+{{- $dbPassword := printf "%016x%016x" (randInt 0 9223372036854775807) (randInt 0 9223372036854775807) }}
+{{- $clusterCA := trim .ClusterCASecret }}
 {{- $dbPort := randInt 10000 17000 }}
 {{- $llmPort := randInt 17000 24000 }}
 {{- $dbUser := "litellm" }}
@@ -20,7 +17,7 @@ version: v4
 
 volumes:
   db:
-    reference: {{ index . "data-volume" }}
+    reference: {{ .DataVolume }}
 
 services:
   # The gateway's state -- virtual keys, per-team budgets, spend history, and the
@@ -29,8 +26,19 @@ services:
   # versions: a mismatched release accepts writes and then never routes the model.
   database:
     image:
-      uri: docker://postgres:{{ index . "postgres-version" }}
-    command: ["docker-entrypoint.sh", "postgres", "-p", "{{ $dbPort }}"]
+      uri: docker://postgres:{{ .PostgresVersion }}
+    script: |
+      #!/bin/bash
+      set -e
+      docker-entrypoint.sh postgres -p {{ $dbPort }} &
+      db_pid=$!
+      # The password is generated fresh at every submit, but a persistent data
+      # volume keeps the one it was initialized with. Re-set it on every start
+      # over the local socket, which the image trusts without a password.
+      until psql -h /var/run/postgresql -p {{ $dbPort }} -U {{ $dbUser }} -d {{ $dbName }} -c "ALTER USER {{ $dbUser }} WITH PASSWORD '{{ $dbPassword }}'" > /dev/null 2>&1; do
+        sleep 2
+      done
+      wait "${db_pid}"
     env:
       - POSTGRES_USER={{ $dbUser }}
       - POSTGRES_PASSWORD={{ $dbPassword }}
@@ -53,24 +61,24 @@ services:
       failure-threshold: 60
     resource:
       cpu:
-        cores: {{ index . "database-cores" }}
+        cores: {{ .DatabaseCores }}
       memory:
-        size: {{ index . "database-memory" }}
+        size: {{ .DatabaseMemory }}
 
   gateway:
     image:
-      uri: docker://ghcr.io/berriai/litellm-database:{{ index . "litellm-version" }}
+      uri: docker://ghcr.io/berriai/litellm-database:{{ .LiteLLMVersion }}
     env:
       - STORE_MODEL_IN_DB=True
-      - DB_PASSWORD={{ $dbPassword }}
+      - DATABASE_URL=postgresql://{{ $dbUser }}:{{ $dbPassword }}@database.svc:{{ $dbPort }}/{{ $dbName }}
       - LITELLM_MASTER_KEY={{ $masterKey }}
       - LITELLM_LOG=INFO
       - SSL_CERT_FILE={{ $caBundle }}
       - LLM_PORT={{ $llmPort }}
-      - DISCOVERY_VALUE={{ index . "discovery-api-value" }}
-      - REFRESH_INTERVAL={{ index . "refresh-interval" }}
-      - TOKEN_TTL={{ index . "token-lifetime" }}
-      - COLD_START_RETRIES={{ index . "cold-start-retries" }}
+      - DISCOVERY_VALUE={{ .DiscoveryApiValue }}
+      - REFRESH_INTERVAL={{ .RefreshInterval }}
+      - TOKEN_TTL={{ .TokenLifetime }}
+      - COLD_START_RETRIES={{ .ColdStartRetries }}
       - FB_CA_BUNDLE={{ $caBundle }}
 {{- if $clusterCA }}
       - CLUSTER_CA_PEM={{ $clusterCA }}
@@ -92,13 +100,10 @@ services:
           port-name: llm
           protocol: http
           type: subdomain
-          scope: {{ .scope }}
+          scope: {{ .ServiceScope }}
     script: |
       #!/bin/bash
       set -e
-      # The password may come from a secret, which the platform only substitutes
-      # as a whole env value -- so the URL is composed here rather than templated.
-      export DATABASE_URL="postgresql://{{ $dbUser }}:${DB_PASSWORD}@database.svc:{{ $dbPort }}/{{ $dbName }}"
       # Prisma's query engines were cached under the image user's HOME. Fuzzball
       # runs the container under a different uid, so without this LiteLLM's schema
       # push tries to re-download them.
@@ -110,8 +115,11 @@ services:
       # downloads over it.
       if [ -f /etc/ssl/certs/ca-certificates.crt ]; then
         cp /etc/ssl/certs/ca-certificates.crt {{ $caBundle }}
-      else
+      elif [ -f /etc/ssl/cert.pem ]; then
         cp /etc/ssl/cert.pem {{ $caBundle }}
+      else
+        echo "FATAL: no system CA bundle found in the gateway image" >&2
+        exit 1
       fi
       if [ -n "${CLUSTER_CA_PEM}" ]; then
         printf '%s\n' "${CLUSTER_CA_PEM}" >> {{ $caBundle }}
@@ -295,13 +303,17 @@ services:
       PYEOF
 
       litellm --port "${LLM_PORT}" &
-      gateway_pid=$!
-
-      # Discovery only makes sense once the admin API answers, and it must not
-      # outlive the process it configures.
       python3 /tmp/reconcile.py &
 
-      wait "${gateway_pid}"
+      # Either process dying takes the service down: litellm without the
+      # reconcile loop keeps answering while its model list and the tokens
+      # behind it silently go stale.
+      set +e
+      wait -n
+      status=$?
+      kill $(jobs -p) 2> /dev/null
+      wait
+      exit "${status}"
     persist: true
     readiness-probe:
       http-get:
@@ -313,9 +325,9 @@ services:
       failure-threshold: 60
     resource:
       cpu:
-        cores: {{ index . "gateway-cores" }}
+        cores: {{ .GatewayCores }}
       memory:
-        size: {{ index . "gateway-memory" }}
+        size: {{ .GatewayMemory }}
 
 jobs:
   show-gateway:
@@ -336,6 +348,10 @@ jobs:
       echo "   fuzzball workflow endpoints list"
       echo ""
 
+      echo "Master key for this gateway (also in the definition: fuzzball workflow get <workflow id>):"
+      echo "   ${MASTER_KEY}"
+      echo ""
+
       echo "Models discovered so far:"
       curl -sf -H "Authorization: Bearer ${MASTER_KEY}" "${GATEWAY}/v1/models" || \
         echo "   (none yet -- annotate a model endpoint with ciq.com/api and ciq.com/model)"
@@ -347,9 +363,9 @@ jobs:
       echo "Create a virtual key:"
       echo "   curl -X POST \\"
       echo "     -H \"Authorization: Bearer <fuzzball token>\" \\"
-      echo "     -H \"x-litellm-api-key: <master key>\" \\"
+      echo "     -H \"x-litellm-api-key: ${MASTER_KEY}\" \\"
       echo "     -H \"Content-Type: application/json\" \\"
-      echo "     <gateway url>key/generate -d '{\"models\": []}'"
+      echo "     <gateway url>/key/generate -d '{\"models\": []}'"
       echo ""
       echo "Then call the gateway with:"
       echo "   Authorization: Bearer <fuzzball token>"

--- a/applications/litellm/template.yaml
+++ b/applications/litellm/template.yaml
@@ -6,6 +6,10 @@
 {{- $masterKey := printf "sk-%016x%016x" (randInt 0 9223372036854775807) (randInt 0 9223372036854775807) }}
 {{- $dbPassword := printf "%016x%016x" (randInt 0 9223372036854775807) (randInt 0 9223372036854775807) }}
 {{- $clusterCA := trim .ClusterCASecret }}
+{{- $dataVolume := trim .DataVolume }}
+{{- if not (hasPrefix "volume://" $dataVolume) }}
+{{- fail "DataVolume must be a volume:// reference, e.g. volume://user/ephemeral" }}
+{{- end }}
 {{- $dbPort := randInt 10000 17000 }}
 {{- $llmPort := randInt 17000 24000 }}
 {{- $dbUser := "litellm" }}
@@ -17,7 +21,7 @@ version: v4
 
 volumes:
   db:
-    reference: {{ .DataVolume }}
+    reference: {{ $dataVolume }}
 
 services:
   # The gateway's state -- virtual keys, per-team budgets, spend history, and the
@@ -32,17 +36,39 @@ services:
       set -e
       docker-entrypoint.sh postgres -p {{ $dbPort }} &
       db_pid=$!
+      # Forward shutdown so postgres exits cleanly; killed with the container
+      # it would leave a persistent volume needing recovery on the next start.
+      trap 'kill -TERM "${db_pid}" 2> /dev/null' TERM INT
       # The password is generated fresh at every submit, but a persistent data
       # volume keeps the one it was initialized with. Re-set it on every start
       # over the local socket, which the image trusts without a password.
-      until psql -h /var/run/postgresql -p {{ $dbPort }} -U {{ $dbUser }} -d {{ $dbName }} -c "ALTER USER {{ $dbUser }} WITH PASSWORD '{{ $dbPassword }}'" > /dev/null 2>&1; do
+      tries=0
+      until psql -h /var/run/postgresql -p {{ $dbPort }} -U {{ $dbUser }} -d {{ $dbName }} -c "ALTER USER {{ $dbUser }} WITH PASSWORD '{{ $dbPassword }}'" > /dev/null 2> /tmp/password-reset.err; do
+        kill -0 "${db_pid}" 2> /dev/null || { echo "FATAL: postgres exited before the password was reset" >&2; exit 1; }
+        tries=$((tries + 1))
+        if [ "${tries}" -ge 60 ]; then
+          echo "FATAL: password reset keeps failing; was the volume initialized by something else?" >&2
+          cat /tmp/password-reset.err >&2
+          exit 1
+        fi
         sleep 2
       done
+      set +e
       wait "${db_pid}"
+      status=$?
+      if [ "${status}" -gt 128 ]; then
+        wait "${db_pid}"
+        status=$?
+      fi
+      exit "${status}"
     env:
       - POSTGRES_USER={{ $dbUser }}
       - POSTGRES_PASSWORD={{ $dbPassword }}
       - POSTGRES_DB={{ $dbName }}
+      # With host networking 127.0.0.1 is the node's loopback, and initdb's
+      # default pg_hba trusts it -- any process on the node would get in as
+      # superuser without the password. Keep trust only on the local socket.
+      - POSTGRES_INITDB_ARGS=--auth-local=trust --auth-host=scram-sha-256
     mounts:
       {{ $dbMount }}:
         volume: db
@@ -130,7 +156,7 @@ services:
       # this workflow's identity can reach. LiteLLM itself is the state of record
       # (read back through /model/info each pass), so a restart of this loop
       # cannot lose track of what is registered.
-      import json, os, ssl, threading, time, urllib.error, urllib.request
+      import datetime, json, os, ssl, threading, time, urllib.error, urllib.request
 
       API = os.environ["FB_OPENAPI_URL"].rstrip("/")
       OWN_WORKFLOW = os.environ.get("FB_WORKFLOW_ID", "")
@@ -159,16 +185,22 @@ services:
           return json.loads(raw) if raw else None
 
       def refresh_token():
-          # Service tokens last seven days. Renew well inside that, and keep the
-          # old one on failure -- it stays valid until its original expiry.
+          # Service tokens last seven days. Renew well inside that; after a
+          # failure retry hourly -- the old token stays valid until its
+          # original expiry, but another four-day sleep would overshoot it.
+          delay = 4 * 24 * 3600
           while True:
-              time.sleep(4 * 24 * 3600)
+              time.sleep(delay)
+              delay = 3600
               try:
                   fresh = call(API + "/v4/workflows:refreshToken", TOKEN[0],
                                method="POST", body=dict(), ctx=CTX)
                   if fresh and fresh.get("token"):
                       TOKEN[0] = fresh["token"]
+                      delay = 4 * 24 * 3600
                       print("TOKEN-REFRESHED", flush=True)
+                  else:
+                      print("TOKEN-REFRESH-FAILED unexpected response", flush=True)
               except Exception as err:
                   print("TOKEN-REFRESH-FAILED", repr(err), flush=True)
 
@@ -241,19 +273,27 @@ services:
           return current
 
       def register(base, model, endpoint_id):
-          token = call(API + "/v4/endpoints/" + endpoint_id + "/token", TOKEN[0],
-                       method="POST", body=dict(expirationSeconds=TTL), ctx=CTX)
+          # Returns the epoch time the minted token really expires: the server
+          # grants at most the workflow token's remaining lifetime, which can
+          # be far less than the TTL requested here.
+          minted = call(API + "/v4/endpoints/" + endpoint_id + "/token", TOKEN[0],
+                        method="POST", body=dict(expirationSeconds=TTL), ctx=CTX)
           params = dict(model="openai/" + model, api_base=base,
-                        api_key=token.get("token"), num_retries=RETRIES)
+                        api_key=minted.get("token"), num_retries=RETRIES)
           call(LLM + "/model/new", MASTER, method="POST",
                body=dict(model_name=model, litellm_params=params))
+          try:
+              stamp = (minted.get("expiresAt") or "").replace("Z", "+00:00")
+              return datetime.datetime.fromisoformat(stamp).timestamp()
+          except ValueError:
+              return time.time() + TTL
 
       def deregister(model_id):
           call(LLM + "/model/delete", MASTER, method="POST", body=dict(id=model_id))
 
       threading.Thread(target=refresh_token, daemon=True).start()
 
-      minted_at = dict()
+      rotate_at = dict()
       while True:
           try:
               wanted = desired(list_endpoints())
@@ -270,23 +310,31 @@ services:
 
           for base, spec in wanted.items():
               known = base in current
-              expiring = known and time.time() - minted_at.get(base, 0) > TTL / 2
+              expiring = known and time.time() >= rotate_at.get(base, 0)
               if known and not expiring:
                   continue
               try:
                   # Rotation adds the replacement before dropping the original,
                   # so the model is never left without a route. Both point at the
                   # same replica, so the momentary duplicate is harmless.
-                  register(base, spec["model"], spec["endpoint"])
-                  minted_at[base] = time.time()
-                  if expiring:
-                      for model_id in current[base]:
-                          deregister(model_id)
-                      print("ROTATED", spec["model"], base, flush=True)
-                  else:
-                      print("REGISTERED", spec["model"], base, flush=True)
+                  granted = register(base, spec["model"], spec["endpoint"])
               except Exception as err:
                   print("REGISTER-FAILED", base, repr(err), flush=True)
+                  continue
+              removed_all = True
+              for model_id in (current.get(base) or []):
+                  try:
+                      deregister(model_id)
+                  except Exception as err:
+                      removed_all = False
+                      print("REMOVE-FAILED stale route kept", base, repr(err), flush=True)
+              if removed_all:
+                  # Halfway to the granted expiry, so a short grant rotates
+                  # early instead of serving a dead token. A failed removal
+                  # leaves rotate_at in the past and the next pass retries the
+                  # whole rotation, stale routes included.
+                  rotate_at[base] = time.time() + (granted - time.time()) / 2
+                  print("ROTATED" if expiring else "REGISTERED", spec["model"], base, flush=True)
 
           for base, model_ids in current.items():
               if base in wanted:
@@ -297,7 +345,7 @@ services:
                       print("REMOVED", base, flush=True)
                   except Exception as err:
                       print("REMOVE-FAILED", base, repr(err), flush=True)
-              minted_at.pop(base, None)
+              rotate_at.pop(base, None)
 
           time.sleep(INTERVAL)
       PYEOF
@@ -305,6 +353,8 @@ services:
       litellm --port "${LLM_PORT}" &
       python3 /tmp/reconcile.py &
 
+      # Forward shutdown to both children so litellm can flush in-flight state.
+      trap 'kill -TERM $(jobs -p) 2> /dev/null' TERM INT
       # Either process dying takes the service down: litellm without the
       # reconcile loop keeps answering while its model list and the tokens
       # behind it silently go stale.
@@ -319,6 +369,7 @@ services:
       http-get:
         path: /health/liveliness
         port: {{ $llmPort }}
+        scheme: HTTP
       initial-delay-seconds: 20
       period-seconds: 10
       timeout-seconds: 5
@@ -383,5 +434,3 @@ jobs:
     policy:
       timeout:
         execute: 10m
-
-defaults: {}

--- a/applications/litellm/values.yaml
+++ b/applications/litellm/values.yaml
@@ -19,9 +19,11 @@ values:
 
   - name: "DataVolume"
     display_name: >-
-      Volume holding the gateway database (virtual keys, budgets, spend history). The
-      default is ephemeral, so all of it is lost when the workflow stops -- use a persistent
-      volume for anything you rely on. Mounted at /var/lib/postgresql/data
+      Volume holding the gateway database (virtual keys, budgets, spend history), as
+      volume://<scope>/<provisioner>[/<volume-name>]. The default is ephemeral, so all of
+      it is lost when the workflow stops -- for anything you rely on, name an existing
+      persistent volume, e.g. volume://user/default/my-gateway-db. Mounted at
+      /var/lib/postgresql/data
     string_value: volume://user/ephemeral
     display_category: "Storage"
 
@@ -41,9 +43,10 @@ values:
 
   - name: "TokenLifetime"
     display_name: >-
-      Seconds an endpoint access token is minted for. The gateway re-mints at half this
-      value, so it also sets how long discovered models keep serving through a Fuzzball API
-      outage.
+      Seconds an endpoint access token is minted for. The gateway re-mints at half the
+      granted lifetime, so it also sets how long discovered models keep serving through a
+      Fuzzball API outage. The server caps grants at the gateway's own token lifetime, at
+      most 7 days.
     uint_value: 14400
     display_category: "Discovery"
 

--- a/applications/litellm/values.yaml
+++ b/applications/litellm/values.yaml
@@ -1,0 +1,98 @@
+values:
+  - name: "MasterKeySecret"
+    display_name: >-
+      Reference to a user-scoped secret holding the LiteLLM master key, which must begin
+      with "sk-" (e.g. secret://user/litellm-master). Required. Used to create virtual keys
+      and to administer the gateway.
+    secret_value:
+      reference: ""
+    display_category: "Secrets"
+
+  - name: "ClusterCASecret"
+    display_name: >-
+      Reference to a user-scoped secret holding a PEM certificate authority. Effectively
+      required on any cluster whose API is served with a private CA: without it the gateway
+      discovers no models and only logs DISCOVERY-FAILED SSL errors. Leave empty only when
+      the cluster API uses a publicly trusted certificate.
+    secret_value:
+      reference: ""
+    display_category: "Secrets"
+
+  - name: "ServiceScope"
+    display_name: >-
+      Who can reach the gateway endpoint. Callers additionally need a LiteLLM virtual key.
+    string_value: group
+    options_input:
+      options: [user, group, organization]
+    display_category: "Access"
+
+  - name: "DataVolume"
+    display_name: >-
+      Volume holding the gateway database (virtual keys, budgets, spend history). The
+      default is ephemeral, so all of it is lost when the workflow stops -- use a persistent
+      volume for anything you rely on. Mounted at /var/lib/postgresql/data
+    string_value: volume://user/ephemeral
+    display_category: "Storage"
+
+  - name: "DiscoveryApiValue"
+    display_name: >-
+      Value of the ciq.com/api endpoint annotation the gateway looks for. Endpoints without
+      it are ignored.
+    string_value: openai
+    display_category: "Discovery"
+
+  - name: "RefreshInterval"
+    display_name: >-
+      Seconds between endpoint discovery passes. Must stay well below the drain-period of
+      the pools being served, so a retiring replica leaves the gateway before it stops.
+    uint_value: 25
+    display_category: "Discovery"
+
+  - name: "TokenLifetime"
+    display_name: >-
+      Seconds an endpoint access token is minted for. The gateway re-mints at half this
+      value, so it also sets how long discovered models keep serving through a Fuzzball API
+      outage.
+    uint_value: 14400
+    display_category: "Discovery"
+
+  - name: "ColdStartRetries"
+    display_name: >-
+      Retries LiteLLM makes against a model whose pool is scaling up from zero. Each retry
+      backs off, so this is what turns a cold start into a successful first request rather
+      than an error.
+    uint_value: 8
+    display_category: "Discovery"
+
+  - name: "GatewayCores"
+    display_name: "Cores for the gateway service."
+    uint_value: 2
+    display_category: "Resources"
+
+  - name: "GatewayMemory"
+    display_name: "Memory for the gateway service."
+    string_value: 3GiB
+    display_category: "Resources"
+
+  - name: "DatabaseCores"
+    display_name: "Cores for the database service."
+    uint_value: 1
+    display_category: "Resources"
+
+  - name: "DatabaseMemory"
+    display_name: "Memory for the database service."
+    string_value: 1GiB
+    display_category: "Resources"
+
+  - name: "LiteLLMVersion"
+    display_name: >-
+      LiteLLM container image tag. v1.97.0 or later is required: earlier releases ignore the
+      x-litellm-api-key header the gateway endpoint depends on. Changing this requires a
+      fresh database.
+    string_value: "v1.97.0"
+    display_category: "Container Versions"
+
+  - name: "PostgresVersion"
+    display_name: "PostgreSQL container image tag."
+    string_value: "16"
+    display_category: "Container Versions"

--- a/applications/litellm/values.yaml
+++ b/applications/litellm/values.yaml
@@ -1,5 +1,5 @@
 values:
-  - name: "MasterKeySecret"
+  - name: "master-key-secret"
     display_name: >-
       Reference to a user-scoped secret holding the LiteLLM master key, which must begin
       with "sk-" (e.g. secret://user/litellm-master). Required. Used to create virtual keys
@@ -8,17 +8,17 @@ values:
       reference: ""
     display_category: "Secrets"
 
-  - name: "DatabasePasswordSecret"
+  - name: "database-password-secret"
     display_name: >-
       Optional reference to a user-scoped secret holding the gateway database password
       (URL-safe characters only). Defaults to a well-known development credential; set it
       on any cluster shared with other users, since the database is reachable on its node.
-      With a persistent DataVolume the password must stay the same across restarts.
+      With a persistent data-volume the password must stay the same across restarts.
     secret_value:
       reference: ""
     display_category: "Secrets"
 
-  - name: "ClusterCASecret"
+  - name: "cluster-ca-secret"
     display_name: >-
       Reference to a user-scoped secret holding a PEM certificate authority. Effectively
       required on any cluster whose API is served with a private CA: without it the gateway
@@ -28,7 +28,7 @@ values:
       reference: ""
     display_category: "Secrets"
 
-  - name: "ServiceScope"
+  - name: "scope"
     display_name: >-
       Who can reach the gateway endpoint. Callers additionally need a LiteLLM virtual key.
     string_value: group
@@ -36,7 +36,7 @@ values:
       options: [user, group, organization]
     display_category: "Access"
 
-  - name: "DataVolume"
+  - name: "data-volume"
     display_name: >-
       Volume holding the gateway database (virtual keys, budgets, spend history). The
       default is ephemeral, so all of it is lost when the workflow stops -- use a persistent
@@ -44,21 +44,21 @@ values:
     string_value: volume://user/ephemeral
     display_category: "Storage"
 
-  - name: "DiscoveryApiValue"
+  - name: "discovery-api-value"
     display_name: >-
       Value of the ciq.com/api endpoint annotation the gateway looks for. Endpoints without
       it are ignored.
     string_value: openai
     display_category: "Discovery"
 
-  - name: "RefreshInterval"
+  - name: "refresh-interval"
     display_name: >-
       Seconds between endpoint discovery passes. Must stay well below the drain-period of
       the pools being served, so a retiring replica leaves the gateway before it stops.
     uint_value: 25
     display_category: "Discovery"
 
-  - name: "TokenLifetime"
+  - name: "token-lifetime"
     display_name: >-
       Seconds an endpoint access token is minted for. The gateway re-mints at half this
       value, so it also sets how long discovered models keep serving through a Fuzzball API
@@ -66,7 +66,7 @@ values:
     uint_value: 14400
     display_category: "Discovery"
 
-  - name: "ColdStartRetries"
+  - name: "cold-start-retries"
     display_name: >-
       Retries LiteLLM makes against a model whose pool is scaling up from zero. Each retry
       backs off, so this is what turns a cold start into a successful first request rather
@@ -74,27 +74,27 @@ values:
     uint_value: 8
     display_category: "Discovery"
 
-  - name: "GatewayCores"
+  - name: "gateway-cores"
     display_name: "Cores for the gateway service."
     uint_value: 2
     display_category: "Resources"
 
-  - name: "GatewayMemory"
+  - name: "gateway-memory"
     display_name: "Memory for the gateway service."
     string_value: 3GiB
     display_category: "Resources"
 
-  - name: "DatabaseCores"
+  - name: "database-cores"
     display_name: "Cores for the database service."
     uint_value: 1
     display_category: "Resources"
 
-  - name: "DatabaseMemory"
+  - name: "database-memory"
     display_name: "Memory for the database service."
     string_value: 1GiB
     display_category: "Resources"
 
-  - name: "LiteLLMVersion"
+  - name: "litellm-version"
     display_name: >-
       LiteLLM container image tag. v1.97.0 or later is required: earlier releases ignore the
       x-litellm-api-key header the gateway endpoint depends on. Changing this requires a
@@ -102,7 +102,7 @@ values:
     string_value: "v1.97.0"
     display_category: "Container Versions"
 
-  - name: "PostgresVersion"
+  - name: "postgres-version"
     display_name: "PostgreSQL container image tag."
     string_value: "16"
     display_category: "Container Versions"

--- a/applications/litellm/values.yaml
+++ b/applications/litellm/values.yaml
@@ -1,24 +1,5 @@
 values:
-  - name: "master-key-secret"
-    display_name: >-
-      Reference to a user-scoped secret holding the LiteLLM master key, which must begin
-      with "sk-" (e.g. secret://user/litellm-master). Required. Used to create virtual keys
-      and to administer the gateway.
-    secret_value:
-      reference: ""
-    display_category: "Secrets"
-
-  - name: "database-password-secret"
-    display_name: >-
-      Optional reference to a user-scoped secret holding the gateway database password
-      (URL-safe characters only). Defaults to a well-known development credential; set it
-      on any cluster shared with other users, since the database is reachable on its node.
-      With a persistent data-volume the password must stay the same across restarts.
-    secret_value:
-      reference: ""
-    display_category: "Secrets"
-
-  - name: "cluster-ca-secret"
+  - name: "ClusterCASecret"
     display_name: >-
       Reference to a user-scoped secret holding a PEM certificate authority. Effectively
       required on any cluster whose API is served with a private CA: without it the gateway
@@ -28,7 +9,7 @@ values:
       reference: ""
     display_category: "Secrets"
 
-  - name: "scope"
+  - name: "ServiceScope"
     display_name: >-
       Who can reach the gateway endpoint. Callers additionally need a LiteLLM virtual key.
     string_value: group
@@ -36,7 +17,7 @@ values:
       options: [user, group, organization]
     display_category: "Access"
 
-  - name: "data-volume"
+  - name: "DataVolume"
     display_name: >-
       Volume holding the gateway database (virtual keys, budgets, spend history). The
       default is ephemeral, so all of it is lost when the workflow stops -- use a persistent
@@ -44,21 +25,21 @@ values:
     string_value: volume://user/ephemeral
     display_category: "Storage"
 
-  - name: "discovery-api-value"
+  - name: "DiscoveryApiValue"
     display_name: >-
       Value of the ciq.com/api endpoint annotation the gateway looks for. Endpoints without
       it are ignored.
     string_value: openai
     display_category: "Discovery"
 
-  - name: "refresh-interval"
+  - name: "RefreshInterval"
     display_name: >-
       Seconds between endpoint discovery passes. Must stay well below the drain-period of
       the pools being served, so a retiring replica leaves the gateway before it stops.
     uint_value: 25
     display_category: "Discovery"
 
-  - name: "token-lifetime"
+  - name: "TokenLifetime"
     display_name: >-
       Seconds an endpoint access token is minted for. The gateway re-mints at half this
       value, so it also sets how long discovered models keep serving through a Fuzzball API
@@ -66,7 +47,7 @@ values:
     uint_value: 14400
     display_category: "Discovery"
 
-  - name: "cold-start-retries"
+  - name: "ColdStartRetries"
     display_name: >-
       Retries LiteLLM makes against a model whose pool is scaling up from zero. Each retry
       backs off, so this is what turns a cold start into a successful first request rather
@@ -74,27 +55,27 @@ values:
     uint_value: 8
     display_category: "Discovery"
 
-  - name: "gateway-cores"
+  - name: "GatewayCores"
     display_name: "Cores for the gateway service."
     uint_value: 2
     display_category: "Resources"
 
-  - name: "gateway-memory"
+  - name: "GatewayMemory"
     display_name: "Memory for the gateway service."
     string_value: 3GiB
     display_category: "Resources"
 
-  - name: "database-cores"
+  - name: "DatabaseCores"
     display_name: "Cores for the database service."
     uint_value: 1
     display_category: "Resources"
 
-  - name: "database-memory"
+  - name: "DatabaseMemory"
     display_name: "Memory for the database service."
     string_value: 1GiB
     display_category: "Resources"
 
-  - name: "litellm-version"
+  - name: "LiteLLMVersion"
     display_name: >-
       LiteLLM container image tag. v1.97.0 or later is required: earlier releases ignore the
       x-litellm-api-key header the gateway endpoint depends on. Changing this requires a
@@ -102,7 +83,7 @@ values:
     string_value: "v1.97.0"
     display_category: "Container Versions"
 
-  - name: "postgres-version"
+  - name: "PostgresVersion"
     display_name: "PostgreSQL container image tag."
-    string_value: "16"
+    string_value: "16.15"
     display_category: "Container Versions"

--- a/applications/litellm/values.yaml
+++ b/applications/litellm/values.yaml
@@ -8,6 +8,16 @@ values:
       reference: ""
     display_category: "Secrets"
 
+  - name: "DatabasePasswordSecret"
+    display_name: >-
+      Optional reference to a user-scoped secret holding the gateway database password
+      (URL-safe characters only). Defaults to a well-known development credential; set it
+      on any cluster shared with other users, since the database is reachable on its node.
+      With a persistent DataVolume the password must stay the same across restarts.
+    secret_value:
+      reference: ""
+    display_category: "Secrets"
+
   - name: "ClusterCASecret"
     display_name: >-
       Reference to a user-scoped secret holding a PEM certificate authority. Effectively


### PR DESCRIPTION
Demo example
https://ctrliq.slack.com/archives/C05UM8YAX2S/p1787251040298309?thread_ts=1787249073.412969&cid=C05UM8YAX2S


----

One OpenAI-compatible base URL in front of every model-serving workflow the launching identity can reach. LiteLLM + Postgres as a workflow, self-configuring from the Fuzzball endpoints API. This is an **illustrative reference entry**: it is meant to be copied as the starting point for more complex gateways, so the reconcile loop is deliberately plain stdlib Python.

- Discovers service endpoints annotated `ciq.com/api: openai` / `ciq.com/model: <name>` and registers one LiteLLM deployment per live pool replica; a pool with no replicas is registered by its pool URL, so a request for an idle model wakes it.
- No pre-created secrets: the LiteLLM master key and the database password are generated at submit time. The `show-gateway` job prints the master key (also visible via `fuzzball workflow get`), and the database re-sets its password over the local trust socket on every start so a persistent data volume keeps working across re-renders. Loopback TCP auth is scram-sha-256 (`POSTGRES_INITDB_ARGS`), since host networking shares the node's loopback.
- Virtual keys, teams, budgets, and spend live in LiteLLM's Postgres (`STORE_MODEL_IN_DB`); callers send a Fuzzball credential in `Authorization` and the LiteLLM key in `x-litellm-api-key` (the proxy consumes `Authorization` on non-public scopes).
- Endpoint access tokens are minted per discovered endpoint with the injected workflow token and rotated at half the expiry the server actually granted (mints are capped at the workflow token's remaining lifetime); a Fuzzball API outage freezes the model list instead of emptying it, and a failed token refresh retries hourly instead of overshooting the 7-day workflow-token expiry.
- Requires a Fuzzball release with pool endpoints / per-replica endpoints / endpoint annotations (fuzzball PR #3173) and LiteLLM >= v1.97.0 (`x-litellm-api-key`). Hold the version-branch backport until the platform work is in a release.

## What the inline script does

```
bash wrapper:
  HOME = /root                       # writable in this image; prisma cache
  SSL_CERT_FILE = system CA bundle + optional ClusterCASecret
  start litellm + reconcile.py; either process exiting stops the service
  (wait -n), and SIGTERM is forwarded so both shut down cleanly

reconcile.py, every RefreshInterval seconds:
  rows    = GET /v4/endpoints        # all pages or nothing; on failure keep
                                     # current models and skip the pass
  serving = rows with ciq.com/api == "openai", excluding this workflow's own

  wanted = {}
  for row in serving:
      pool row with live replica rows -> skip   # replicas registered instead
      pool row with no replicas       -> keep   # the wake doorbell
      wanted[row.url + "/v1"] = (ciq.com/model, endpoint id)

  current = GET litellm /model/info grouped by api_base
            # a 500 saying "LLM Model List not loaded" means the table is
            # empty (fresh database), not broken -> treat as no models

  for base in wanted missing from current, or past half the granted expiry:
      token = POST /v4/endpoints/{id}/token     # response carries expiresAt
      POST /model/new {model, api_base, api_key=token, num_retries=ColdStartRetries}
      on rotation: add the replacement first, then delete the old ids; a
      failed delete is logged REMOVE-FAILED and the whole rotation retries
      next pass, so a dead-token route never lingers silently

  for base in current missing from wanted:
      POST /model/delete               # replica drained / pool gone

background thread: re-mint the workflow token via /workflows:refreshToken
```

## Testing

- Rendered/validated/scored against a live cluster; fail guards verified (missing `volume://` prefix, bad values).
- Live on a kind deployment: passwordless loopback psql is refused while the socket reset path works; stop/start over a persistent volume shows a clean postgres shutdown (SIGTERM trap) and the new render's password taking effect via `ALTER USER`; a virtual key minted under one workflow instance keeps working under the next instance's regenerated master key (keys are hash-validated); killing `reconcile.py` stops the gateway service immediately.
- The reconcile loop's registration/rotation paths were exercised against a mock endpoints+LiteLLM API pair (the available server build predates endpoint annotations): fresh-database bootstrap via the narrowed 500 handler, rotation honoring a server-clamped 12s grant with `TokenLifetime=3600`, convergence after an injected `/model/delete` failure, deregistration on endpoint disappearance, and own-workflow exclusion.
- Full end-to-end discovery/registration/streaming/wake-from-zero was previously verified on a cluster running the fuzz8343 platform work.
