### PR TITLE
FUZZ-8338 RAG catalog entry

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,10 @@ docs may show them. Write new instructions against `fuzzball workflow catalog`.
 
 ## Style guide
 
+- Value names in `values.yaml` are **PascalCase** (`MinReplicas`,
+  `HfTokenSecret`), referenced in `template.yaml` as direct fields
+  (`.MinReplicas`, never `index . "min-replicas"`). Keep `metadata.md`
+  usage examples (`--values Name=...`) in the same casing.
 - Application templates should follow a style consistent with the existing
   templates listed below and the [style guide](StyleGuide.md).
   - bwa_alignment

--- a/StyleGuide.md
+++ b/StyleGuide.md
@@ -3,6 +3,10 @@
 
 Workflows should follow these suggestions.
 
+- Name template values in PascalCase (`MinReplicas`, `HfTokenSecret`, `Image`)
+  and reference them in templates as direct fields (`.MinReplicas`). Do not use
+  kebab-case or snake_case names — they force `index . "min-replicas"` lookups
+  and diverge from every user-facing `--values Name=...` example.
 - Prefer `script:` over `command:` for new workflows for better readability and
   maintainability for complex operations.
 - Do not make hardware assumptions. For example, hardcoding `threads: true` in

--- a/applications/rag/README.md
+++ b/applications/rag/README.md
@@ -1,0 +1,16 @@
+# rag — workflow catalog entry
+
+Catalog entry for a RAG corpus service built on haiku.rag (see metadata.md).
+
+The container image this entry consumes (`image` value) is built from
+`definition_files/haiku-rag.def` by this repo's container CI
+(`.github/workflows/build-containers.yaml`): PRs touching the definition get a
+PR-scoped tag for testing, and merging retags that exact image to the release
+tag `rag-haiku-rag:<version>-<arch>` on ghcr.
+
+The image bundles the full haiku.rag package with the ingester extra, bakes
+the document-parsing models for air-gapped operation (docling ships its model
+weights outside the HF cache — the definition pins HF_HOME, DOCLING_CACHE_DIR,
+and DOCLING_ARTIFACTS_PATH), pins CPU-only torch (parsing is CPU-bound;
+embeddings/generation are remote), and carries the `analysis.enabled` gate
+patch until upstream haiku.rag ships it.

--- a/applications/rag/README.md
+++ b/applications/rag/README.md
@@ -2,7 +2,7 @@
 
 Catalog entry for a RAG corpus service built on haiku.rag (see metadata.md).
 
-The container image this entry consumes (`image` value) is built from
+The container image this entry consumes (`Image` value) is built from
 `definition_files/haiku-rag.def` by this repo's container CI
 (`.github/workflows/build-containers.yaml`): PRs touching the definition get a
 PR-scoped tag for testing, and merging retags that exact image to the release

--- a/applications/rag/definition_files/haiku-rag.def
+++ b/applications/rag/definition_files/haiku-rag.def
@@ -1,0 +1,114 @@
+# tag: 0.78.0-0
+#
+# haiku.rag runtime for the rag catalog entry: full haiku.rag (in-process
+# docling parsing + OCR) plus the slim package's ingester extra, with parsing
+# models baked in so workflows need no egress beyond their configured model
+# endpoint, and the analysis-gate patch (analysis.enabled config for the
+# code-execution MCP tool; submitted upstream -- drop the patch step once a
+# release carries it).
+
+Bootstrap: docker
+From: python:3.13-slim
+
+%post
+set -e
+
+# Runtime shared libraries for opencv (cv2), which docling's tableformer and
+# rapidocr both import; the slim base omits them ("No OCR engine found" at
+# parse time is the cv2 import failing, not a missing OCR package).
+apt-get update
+apt-get install -y --no-install-recommends libgl1 libglib2.0-0 libxcb1
+rm -rf /var/lib/apt/lists/*
+
+# CPU-only torch, pinned first so the haiku.rag install below treats it as
+# satisfied: parsing runs on CPU and embeddings/generation are remote, while
+# the default wheels drag in the multi-GB CUDA stack.
+pip install --no-cache-dir --index-url https://download.pytorch.org/whl/cpu \
+    torch==2.13.0 torchvision==0.28.0
+
+HAIKU_RAG_VERSION=0.78.0
+pip install --no-cache-dir \
+    "haiku.rag==${HAIKU_RAG_VERSION}" \
+    "haiku.rag-slim[ingester]==${HAIKU_RAG_VERSION}"
+
+# Analysis-gate patch: adds analysis.enabled and deregisters the analyze
+# (code-execution) MCP tool when disabled. Anchored so an upstream layout
+# change fails the build instead of silently shipping unpatched.
+cat <<'__EOF__' > /tmp/analyze-gate.py
+import re
+import sys
+from pathlib import Path
+
+import haiku.rag as pkg
+
+root = Path(pkg.__file__).parent
+
+models = root / "config" / "models.py"
+s = models.read_text()
+m = re.search(
+    r'class AnalysisConfig\(ConfigModel\):\n(?:    """(?:.|\n)*?"""\n)?((?:    .*\n|\n)*)', s
+)
+if not m:
+    sys.exit("AnalysisConfig anchor not found -- upstream layout changed")
+if "enabled: bool" not in m.group(1):
+    insert_at = m.start(1)
+    models.write_text(s[:insert_at] + "\n    enabled: bool = True\n" + s[insert_at:])
+
+mcp = root / "mcp.py"
+s = mcp.read_text()
+if "analysis.enabled" not in s:
+    if s.count("    return mcp") != 1:
+        sys.exit("mcp.py return anchor not found -- upstream layout changed")
+    s = s.replace(
+        "    return mcp",
+        '    if not config.analysis.enabled:\n        mcp.remove_tool("analyze")\n\n    return mcp',
+        1,
+    )
+    mcp.write_text(s)
+
+print("analyze gate applied")
+__EOF__
+python /tmp/analyze-gate.py
+rm /tmp/analyze-gate.py
+
+# Bake parsing models for air-gapped operation. All three env knobs matter:
+# docling ignores XDG/HF paths and caches its model weights (the bulk,
+# including RapidOCR) under $HOME/.cache/docling unless DOCLING_CACHE_DIR is
+# set; HF_HOME only ends up holding hub references. DOCLING_ARTIFACTS_PATH
+# makes runtime load straight from the bake with no download attempt. The
+# same three are exported in %environment so any runtime UID sees them.
+export HF_HOME=/opt/models/hf
+export DOCLING_CACHE_DIR=/opt/models/docling
+export DOCLING_ARTIFACTS_PATH=/opt/models/docling/models
+cat <<'__EOF__' > /tmp/bake-config.yaml
+environment: production
+storage:
+  data_dir: /tmp/bake
+processing:
+  converter: docling-local
+  chunker: docling-local
+  chunker_type: hybrid
+  auto_title: false
+__EOF__
+haiku-rag --config /tmp/bake-config.yaml download-models
+rm -rf /tmp/bake-config.yaml /tmp/bake
+chmod -R a+rX /opt/models
+
+# Fail the build rather than ship a SIF that breaks at first parse.
+python - <<'__EOF__'
+import os
+
+from haiku.rag.config.models import AnalysisConfig
+
+assert "enabled" in AnalysisConfig.model_fields, "analyze gate missing"
+import cv2  # noqa: F401  (docling tableformer + rapidocr both need it)
+import rapidocr  # noqa: F401
+models = "/opt/models/docling/models"
+assert os.path.isdir(models) and os.listdir(models), "docling model bake missing"
+print("build verification ok")
+__EOF__
+
+%environment
+export HF_HOME=/opt/models/hf
+export DOCLING_CACHE_DIR=/opt/models/docling
+export DOCLING_ARTIFACTS_PATH=/opt/models/docling/models

--- a/applications/rag/definition_files/haiku-rag.def
+++ b/applications/rag/definition_files/haiku-rag.def
@@ -26,6 +26,7 @@ rm -rf /var/lib/apt/lists/*
 pip install --no-cache-dir --index-url https://download.pytorch.org/whl/cpu \
     torch==2.13.0 torchvision==0.28.0
 
+# Keep in sync with the '# tag:' comment at the top of this file.
 HAIKU_RAG_VERSION=0.78.0
 pip install --no-cache-dir \
     "haiku.rag==${HAIKU_RAG_VERSION}" \

--- a/applications/rag/definition_files/haiku-rag.def
+++ b/applications/rag/definition_files/haiku-rag.def
@@ -80,10 +80,28 @@ rm /tmp/analyze-gate.py
 export HF_HOME=/opt/models/hf
 export DOCLING_CACHE_DIR=/opt/models/docling
 export DOCLING_ARTIFACTS_PATH=/opt/models/docling/models
+# The embeddings/qa blocks pin the openai provider with placeholder targets:
+# haiku.rag's DEFAULTS are ollama models, and download-models pulls every
+# ollama-provider model in the effective config -- with the defaults it dials
+# localhost:11434 and fails the build. openai-provider models are remote, so
+# nothing is downloaded for them (mirrors the entry's runtime config).
 cat <<'__EOF__' > /tmp/bake-config.yaml
 environment: production
 storage:
   data_dir: /tmp/bake
+embeddings:
+  model:
+    provider: openai
+    name: bake-placeholder
+    vector_dim: 768
+    base_url: http://bake-placeholder.invalid/v1
+    api_key: bake
+qa:
+  model:
+    provider: openai
+    name: bake-placeholder
+    base_url: http://bake-placeholder.invalid/v1
+    api_key: bake
 processing:
   converter: docling-local
   chunker: docling-local

--- a/applications/rag/metadata.md
+++ b/applications/rag/metadata.md
@@ -1,0 +1,88 @@
+# Copyright 2026 CIQ, Inc. All rights reserved.
+---
+id: "ciq/ml_and_ai/rag"
+name: "rag"
+category: "ML_AND_AI"
+tags:
+- RAG
+- LLM
+- MCP
+- vector search
+- retrieval
+---
+This workflow runs a retrieval-augmented-generation (RAG) corpus service built on
+[haiku.rag](https://github.com/ggozad/haiku.rag): document ingestion (PDF, DOCX,
+PPTX, HTML, plain text — including OCR for scanned PDFs), hybrid vector +
+full-text search with citation metadata, and retrieval exposed as **MCP tools**
+over streamable HTTP that any MCP-capable agent can call from outside the
+cluster. The corpus and its index are files on the workflow's volume (embedded
+LanceDB) — there is no database service to operate.
+
+```
+fuzzball workflow catalog start rag
+fuzzball workflow catalog start rag --values Volume=corpus,Endpoint=https://<vllm-endpoint-url>/v1
+fuzzball workflow catalog start rag --values Volume=corpus,Endpoint=...,EmbeddingModel=Qwen/Qwen3-Embedding-8B,EmbeddingDim=4096
+fuzzball workflow catalog start rag --values Volume=corpus,Endpoint=...,ReadOnly=false
+```
+
+Embeddings (and generation, when `GenerationModel` is set) are served by the
+OpenAI-compatible `Endpoint` — typically the `vllm` catalog entry or a LiteLLM
+gateway. When the endpoint is another Fuzzball workflow endpoint in your scope,
+authentication works out of the box: the workflow's injected `FB_TOKEN` is used
+as the bearer token unless you set `EndpointToken`. The workflow makes no
+network connections beyond the configured endpoint, so it operates air-gapped
+(document-parsing models are baked into the image).
+
+## Ingestion
+
+With the default `ReadOnly=true`, ingestion runs through a dedicated ingester
+service:
+
+- **Inbox directory**: any file placed under `/data/inbox` on the volume is
+  ingested automatically; re-adding a changed file replaces its previous
+  content instead of duplicating it.
+- **Jobs monitoring API** on the `ingest` endpoint (bearer token in the rendered
+  workflow definition): `GET /jobs` and `GET /jobs/{id}` report each document's
+  status (queued/claimed/succeeded/failed), with retry and a dead-letter queue.
+  Failed documents leave no partial content in the corpus. Submission itself
+  happens through the inbox (or the MCP write tools with `ReadOnly=false`) --
+  the API monitors and manages jobs, it does not accept uploads.
+
+With `ReadOnly=false`, no ingester runs and the MCP surface itself exposes
+document-management tools (add/delete) alongside retrieval.
+
+## Retrieval over MCP
+
+The `mcp` endpoint serves MCP over streamable HTTP. Configure an agent with the
+endpoint URL and, for non-public scopes, the Fuzzball endpoint token in the
+`Authorization` header:
+
+```json
+{
+  "url": "https://<mcp-endpoint-host>/mcp",
+  "headers": { "Authorization": "Bearer <fuzzball endpoint token>" }
+}
+```
+
+With the default `ReadOnly=true`, the MCP surface exposes retrieval only
+(`search_documents`, `get_document`, `list_documents`, `ask_question`). Document
+management tools appear only with `ReadOnly=false`; the code-execution analysis
+tool is disabled by this entry in both modes. Search results carry the
+source document URI, page numbers, and heading paths for citation.
+
+## Model consistency
+
+The corpus is bound to its embedding model. Query and corpus embeddings always
+use the same model; pointing the entry at an existing corpus with a different
+`EmbeddingModel` or `EmbeddingDim` fails at startup naming the conflict. To
+migrate a corpus to a new embedding model, run
+`haiku-rag rebuild --set-embedder` against the volume (documents are re-embedded
+from stored text; no re-ingestion needed).
+
+## Persistence
+
+The default `Volume=ephemeral` is for evaluation only — cancelling the workflow
+destroys the corpus. For real use, create a persistent volume and pass its name
+(`Volume=corpus`): ingest, cancel the workflow, start a new one on the same
+volume, and searches return the same results. One corpus per workflow; separate
+corpora get separate volumes and endpoint scopes.

--- a/applications/rag/metadata.md
+++ b/applications/rag/metadata.md
@@ -20,18 +20,19 @@ LanceDB) — there is no database service to operate.
 
 ```
 fuzzball workflow catalog start rag
-fuzzball workflow catalog start rag --values Volume=corpus,Endpoint=https://<vllm-endpoint-url>/v1
+fuzzball workflow catalog start rag --values Volume=corpus,Endpoint=https://<vllm-endpoint-url>/v1,EndpointTokenSecret=secret://user/<name>
 fuzzball workflow catalog start rag --values Volume=corpus,Endpoint=...,EmbeddingModel=Qwen/Qwen3-Embedding-8B,EmbeddingDim=4096
 fuzzball workflow catalog start rag --values Volume=corpus,Endpoint=...,ReadOnly=false
 ```
 
 Embeddings (and generation, when `GenerationModel` is set) are served by the
 OpenAI-compatible `Endpoint` — typically the `vllm` catalog entry or a LiteLLM
-gateway. When the endpoint is another Fuzzball workflow endpoint in your scope,
-authentication works out of the box: the workflow's injected `FB_TOKEN` is used
-as the bearer token unless you set `EndpointToken`. The workflow makes no
-network connections beyond the configured endpoint, so it operates air-gapped
-(document-parsing models are baked into the image).
+gateway. When the endpoint is another Fuzzball workflow endpoint, mint a bearer
+token for it (`fuzzball workflow endpoints generate-token <endpoint-id>
+--expiration <lifetime>` — size the lifetime to this service's; the default is
+short), store it in a secret, and pass it as `EndpointTokenSecret`. The
+workflow makes no network connections beyond the configured endpoint, so it
+operates air-gapped (document-parsing models are baked into the image).
 
 ## Ingestion
 

--- a/applications/rag/template.yaml
+++ b/applications/rag/template.yaml
@@ -186,6 +186,16 @@ services:
     script: |
       #!/bin/sh
       set -e
+      # Python TLS stacks need an explicit CA file: the platform mounts the
+      # cluster CA under /run/fuzzball-substrate/trusted-certs and sets
+      # SSL_CERT_DIR, but OpenSSL-style directory lookup needs hash-named
+      # entries, so httpx misses it. Merge it with the bundled public CAs so
+      # both cluster-internal and public endpoints verify.
+      if ls /run/fuzzball-substrate/trusted-certs/*.crt >/dev/null 2>&1 && [ -z "${SSL_CERT_FILE:-}" ]; then
+        cat "$(python -c 'import certifi; print(certifi.where())')" \
+            /run/fuzzball-substrate/trusted-certs/*.crt > /tmp/ca-bundle.pem
+        export SSL_CERT_FILE=/tmp/ca-bundle.pem
+      fi
       mkdir -p /data/inbox
       haiku-rag --config /app/haiku.rag.yaml init
       exec haiku-ingester --config /app/haiku.rag.yaml serve
@@ -245,6 +255,12 @@ services:
     script: |
       #!/bin/sh
       set -e
+      # See the ingester script: explicit CA file for python TLS stacks.
+      if ls /run/fuzzball-substrate/trusted-certs/*.crt >/dev/null 2>&1 && [ -z "${SSL_CERT_FILE:-}" ]; then
+        cat "$(python -c 'import certifi; print(certifi.where())')" \
+            /run/fuzzball-substrate/trusted-certs/*.crt > /tmp/ca-bundle.pem
+        export SSL_CERT_FILE=/tmp/ca-bundle.pem
+      fi
       {{- if not $read_only }}
       haiku-rag --config /app/haiku.rag.yaml init
       {{- end }}

--- a/applications/rag/template.yaml
+++ b/applications/rag/template.yaml
@@ -156,10 +156,14 @@ services:
       {{- end }}
     files:
       /app/haiku.rag.yaml: file://haiku-config
-    {{- if $endpoint_token_secret }}
     env:
+      # Parsing models are baked into the image; offline mode stops the
+      # chunking tokenizer's online HF metadata check (air-gap has no HF
+      # egress, and the check adds nothing when the cache is baked).
+      - HF_HUB_OFFLINE=1
+      {{- if $endpoint_token_secret }}
       - RAG_ENDPOINT_TOKEN={{ $endpoint_token_secret }}
-    {{- end }}
+      {{- end }}
     mounts:
       /data:
         volume: data
@@ -209,10 +213,14 @@ services:
       {{- end }}
     files:
       /app/haiku.rag.yaml: file://haiku-config
-    {{- if $endpoint_token_secret }}
     env:
+      # Parsing models are baked into the image; offline mode stops the
+      # chunking tokenizer's online HF metadata check (air-gap has no HF
+      # egress, and the check adds nothing when the cache is baked).
+      - HF_HUB_OFFLINE=1
+      {{- if $endpoint_token_secret }}
       - RAG_ENDPOINT_TOKEN={{ $endpoint_token_secret }}
-    {{- end }}
+      {{- end }}
     mounts:
       /data:
         volume: data

--- a/applications/rag/template.yaml
+++ b/applications/rag/template.yaml
@@ -107,14 +107,17 @@ files:
         base_url: "{{ $endpoint }}"
         api_key: "{{ $api_key }}"
       batch_size: 64
-    {{- if $generation_model }}
+    {{- /* Always pin qa to the openai provider: haiku.rag's built-in default
+           is an ollama model, so leaving qa unset would make ask_question
+           dial a nonexistent localhost ollama. With no GenerationModel the
+           placeholder name turns the failure into a self-explanatory
+           "model 'generation-model-not-configured' not found". */}}
     qa:
       model:
         provider: openai
-        name: "{{ $generation_model }}"
+        name: "{{ $generation_model | default "generation-model-not-configured" }}"
         base_url: "{{ $endpoint }}"
         api_key: "{{ $api_key }}"
-    {{- end }}
     analysis:
       enabled: false
     processing:

--- a/applications/rag/template.yaml
+++ b/applications/rag/template.yaml
@@ -23,12 +23,17 @@
   {{- fail "GenerationModel must not contain quotes or backslashes" }}
 {{- end }}
 {{- $endpoint_token_secret := trim .EndpointTokenSecret }}
-{{- if or (contains "\"" $endpoint_token_secret) (contains "\\" $endpoint_token_secret) (contains "\n" $endpoint_token_secret) }}
-  {{- fail "EndpointTokenSecret must not contain quotes or backslashes" }}
+{{- if or (contains "\"" $endpoint_token_secret) (contains "\\" $endpoint_token_secret) (contains "\n" $endpoint_token_secret) (contains "#" $endpoint_token_secret) }}
+  {{- fail "EndpointTokenSecret must not contain quotes, backslashes, or comments" }}
 {{- end }}
 {{- $endpoint_token := trim .EndpointToken }}
 {{- if or (contains "\"" $endpoint_token) (contains "\\" $endpoint_token) (contains "\n" $endpoint_token) }}
   {{- fail "EndpointToken must not contain quotes or backslashes" }}
+{{- end }}
+{{- if and (or $endpoint_token $endpoint_token_secret) (not $endpoint) }}
+  {{- /* Without an endpoint the OpenAI client dials api.openai.com; a real
+         credential must never be sent there by accident. */}}
+  {{- fail "EndpointToken/EndpointTokenSecret require Endpoint to be set" }}
 {{- end }}
 
 {{- $scope := lower (trim .Scope) }}
@@ -71,13 +76,12 @@
   {{- $api_key = "${RAG_ENDPOINT_TOKEN}" }}
 {{- end }}
 {{- if and (not $api_key) $endpoint }}
-  {{- /* haiku.rag substitutes ${FB_TOKEN} from the environment at runtime; the
-         workflow-scoped token is injected into every container and is the right
-         credential when the endpoint is another Fuzzball workflow endpoint.
-         Only defaulted when an endpoint is set: with no endpoint, OpenAI-style
-         clients fall back to api.openai.com, and the workflow token must never
-         be sent there. */}}
-  {{- $api_key = "${FB_TOKEN}" }}
+  {{- /* The OpenAI client requires a non-empty key even against endpoints
+         that ignore it, so default a placeholder. Deliberately NOT the
+         workflow's FB_TOKEN: the endpoint proxy rejects other workflows'
+         tokens (verified), and a real credential must never be sent to an
+         arbitrary user-configured endpoint by default. */}}
+  {{- $api_key = "unused" }}
 {{- end }}
 {{- $mcp_port := randInt 24001 28000 }}
 {{- $ingester_port := randInt 28001 32000 }}
@@ -150,9 +154,9 @@ services:
   ingester:
     persist: true
     image:
-      uri: {{ $image }}
+      uri: "{{ $image }}"
       {{- if $image_secret }}
-      secret: {{ $image_secret }}
+      secret: "{{ $image_secret }}"
       {{- end }}
     files:
       /app/haiku.rag.yaml: file://haiku-config
@@ -192,8 +196,10 @@ services:
       # entries, so httpx misses it. Merge it with the bundled public CAs so
       # both cluster-internal and public endpoints verify.
       if ls /run/fuzzball-substrate/trusted-certs/*.crt >/dev/null 2>&1 && [ -z "${SSL_CERT_FILE:-}" ]; then
-        cat "$(python -c 'import certifi; print(certifi.where())')" \
-            /run/fuzzball-substrate/trusted-certs/*.crt > /tmp/ca-bundle.pem
+        cat "$(python -c 'import certifi; print(certifi.where())')" > /tmp/ca-bundle.pem
+        for f in /run/fuzzball-substrate/trusted-certs/*.crt; do
+          cat "$f" >> /tmp/ca-bundle.pem; echo >> /tmp/ca-bundle.pem
+        done
         export SSL_CERT_FILE=/tmp/ca-bundle.pem
       fi
       mkdir -p /data/inbox
@@ -217,9 +223,9 @@ services:
         status: running
     {{- end }}
     image:
-      uri: {{ $image }}
+      uri: "{{ $image }}"
       {{- if $image_secret }}
-      secret: {{ $image_secret }}
+      secret: "{{ $image_secret }}"
       {{- end }}
     files:
       /app/haiku.rag.yaml: file://haiku-config
@@ -257,8 +263,10 @@ services:
       set -e
       # See the ingester script: explicit CA file for python TLS stacks.
       if ls /run/fuzzball-substrate/trusted-certs/*.crt >/dev/null 2>&1 && [ -z "${SSL_CERT_FILE:-}" ]; then
-        cat "$(python -c 'import certifi; print(certifi.where())')" \
-            /run/fuzzball-substrate/trusted-certs/*.crt > /tmp/ca-bundle.pem
+        cat "$(python -c 'import certifi; print(certifi.where())')" > /tmp/ca-bundle.pem
+        for f in /run/fuzzball-substrate/trusted-certs/*.crt; do
+          cat "$f" >> /tmp/ca-bundle.pem; echo >> /tmp/ca-bundle.pem
+        done
         export SSL_CERT_FILE=/tmp/ca-bundle.pem
       fi
       {{- if not $read_only }}

--- a/applications/rag/template.yaml
+++ b/applications/rag/template.yaml
@@ -1,0 +1,248 @@
+# Copyright 2026 CIQ, Inc. All rights reserved.
+
+{{- /* Structural integrity only: a quote or backslash in a value would corrupt
+       the rendered YAML (workflow doc and the embedded haiku.rag config file);
+       semantic validity is the server's / haiku.rag's job. */}}
+{{- $endpoint := trim .Endpoint }}
+{{- if or (contains "\"" $endpoint) (contains "\\" $endpoint) (contains "\n" $endpoint) }}
+  {{- fail "Endpoint must not contain quotes or backslashes" }}
+{{- end }}
+{{- $embedding_model := trim .EmbeddingModel }}
+{{- if not $embedding_model }}
+  {{- fail "EmbeddingModel must not be empty" }}
+{{- end }}
+{{- if or (contains "\"" $embedding_model) (contains "\\" $embedding_model) (contains "\n" $embedding_model) }}
+  {{- fail "EmbeddingModel must not contain quotes or backslashes" }}
+{{- end }}
+{{- $embedding_dim := int .EmbeddingDim }}
+{{- if lt $embedding_dim 1 }}
+  {{- fail "EmbeddingDim must be at least 1" }}
+{{- end }}
+{{- $generation_model := trim .GenerationModel }}
+{{- if or (contains "\"" $generation_model) (contains "\\" $generation_model) (contains "\n" $generation_model) }}
+  {{- fail "GenerationModel must not contain quotes or backslashes" }}
+{{- end }}
+{{- $endpoint_token_secret := trim .EndpointTokenSecret }}
+{{- if or (contains "\"" $endpoint_token_secret) (contains "\\" $endpoint_token_secret) (contains "\n" $endpoint_token_secret) }}
+  {{- fail "EndpointTokenSecret must not contain quotes or backslashes" }}
+{{- end }}
+{{- $endpoint_token := trim .EndpointToken }}
+{{- if or (contains "\"" $endpoint_token) (contains "\\" $endpoint_token) (contains "\n" $endpoint_token) }}
+  {{- fail "EndpointToken must not contain quotes or backslashes" }}
+{{- end }}
+
+{{- $scope := lower (trim .Scope) }}
+{{- if not (has $scope (list "user" "group" "organization" "public")) }}
+  {{- fail "Scope must be one of: user, group, organization, public" }}
+{{- end }}
+
+{{- $volume := trim .Volume }}
+{{- if not $volume }}
+  {{- fail "Volume must be 'ephemeral' or the name of a persistent volume" }}
+{{- end }}
+{{- if or (contains "\"" $volume) (contains "\\" $volume) (contains "\n" $volume) }}
+  {{- fail "Volume must not contain quotes or backslashes" }}
+{{- end }}
+
+{{- $chunk_size := int .ChunkSize }}
+{{- if lt $chunk_size 16 }}
+  {{- fail "ChunkSize must be at least 16 tokens" }}
+{{- end }}
+
+{{- $mcp_memory := trim .McpMemory }}
+{{- $ingester_memory := trim .IngesterMemory }}
+{{- $image := trim .Image }}
+{{- range $v := list $mcp_memory $ingester_memory $image }}
+  {{- if or (not $v) (contains "\"" $v) (contains "\\" $v) (contains "\n" $v) (contains "#" $v) }}
+    {{- fail "McpMemory, IngesterMemory, and Image must be non-empty and free of quotes, backslashes, and comments" }}
+  {{- end }}
+{{- end }}
+{{- $image_secret := trim .ImageSecret }}
+{{- if or (contains "\"" $image_secret) (contains "\\" $image_secret) (contains "\n" $image_secret) (contains "#" $image_secret) }}
+  {{- fail "ImageSecret must not contain quotes, backslashes, or comments" }}
+{{- end }}
+
+{{- $read_only := .ReadOnly }}
+{{- $api_key := $endpoint_token }}
+{{- if $endpoint_token_secret }}
+  {{- /* Secret injected as an env var (env supports secret:// references);
+         haiku.rag substitutes it at runtime so it never appears in the
+         rendered definition. */}}
+  {{- $api_key = "${RAG_ENDPOINT_TOKEN}" }}
+{{- end }}
+{{- if and (not $api_key) $endpoint }}
+  {{- /* haiku.rag substitutes ${FB_TOKEN} from the environment at runtime; the
+         workflow-scoped token is injected into every container and is the right
+         credential when the endpoint is another Fuzzball workflow endpoint.
+         Only defaulted when an endpoint is set: with no endpoint, OpenAI-style
+         clients fall back to api.openai.com, and the workflow token must never
+         be sent there. */}}
+  {{- $api_key = "${FB_TOKEN}" }}
+{{- end }}
+{{- $mcp_port := randInt 24001 28000 }}
+{{- $ingester_port := randInt 28001 32000 }}
+{{- $ingester_token := printf "rt-%d%d%d%d" (randInt 100000000 999999999) (randInt 100000000 999999999) (randInt 100000000 999999999) (randInt 100000000 999999999) }}
+
+version: v4
+
+volumes:
+  data:
+    {{- if eq (lower $volume) "ephemeral" }}
+    use: ephemeral
+    {{- else }}
+    use: persistent
+    name: "{{ $volume }}"
+    {{- end }}
+
+files:
+  haiku-config: |
+    environment: production
+    storage:
+      data_dir: /data
+    embeddings:
+      model:
+        provider: openai
+        name: "{{ $embedding_model }}"
+        vector_dim: {{ $embedding_dim }}
+        base_url: "{{ $endpoint }}"
+        api_key: "{{ $api_key }}"
+      batch_size: 64
+    {{- if $generation_model }}
+    qa:
+      model:
+        provider: openai
+        name: "{{ $generation_model }}"
+        base_url: "{{ $endpoint }}"
+        api_key: "{{ $api_key }}"
+    {{- end }}
+    analysis:
+      enabled: false
+    processing:
+      chunk_size: {{ $chunk_size }}
+      converter: docling-local
+      chunker: docling-local
+      chunker_type: hybrid
+      auto_title: false
+    {{- if $read_only }}
+    ingester:
+      queue:
+        path: /data/ingester.db
+      api:
+        host: 0.0.0.0
+        port: {{ $ingester_port }}
+        auth_token: "{{ $ingester_token }}"
+      sources:
+        - type: fs
+          id: inbox
+          root: /data/inbox
+          delete_orphans: false
+    {{- end }}
+
+services:
+  {{- if $read_only }}
+
+  # The single LanceDB writer: owns database creation and all ingestion (async
+  # job queue + the /data/inbox watch directory). The MCP service reads the
+  # same database read-only.
+  ingester:
+    persist: true
+    image:
+      uri: {{ $image }}
+      {{- if $image_secret }}
+      secret: {{ $image_secret }}
+      {{- end }}
+    files:
+      /app/haiku.rag.yaml: file://haiku-config
+    {{- if $endpoint_token_secret }}
+    env:
+      - RAG_ENDPOINT_TOKEN={{ $endpoint_token_secret }}
+    {{- end }}
+    mounts:
+      /data:
+        volume: data
+    resource:
+      cpu:
+        cores: {{ .IngesterCores }}
+      memory:
+        size: {{ $ingester_memory }}
+    network:
+      ports:
+        - name: ingest-api
+          port: {{ $ingester_port }}
+          protocol: tcp
+      endpoints:
+        - name: ingest
+          port-name: ingest-api
+          protocol: http
+          type: subdomain
+          scope: {{ $scope }}
+    script: |
+      #!/bin/sh
+      set -e
+      mkdir -p /data/inbox
+      haiku-rag --config /app/haiku.rag.yaml init
+      exec haiku-ingester --config /app/haiku.rag.yaml serve
+    readiness-probe:
+      tcp-socket:
+        port: {{ $ingester_port }}
+      initial-delay-seconds: 15
+      period-seconds: 10
+      timeout-seconds: 5
+      failure-threshold: 30
+      success-threshold: 1
+  {{- end }}
+
+  mcp:
+    persist: true
+    {{- if $read_only }}
+    depends-on:
+      - name: ingester
+        status: running
+    {{- end }}
+    image:
+      uri: {{ $image }}
+      {{- if $image_secret }}
+      secret: {{ $image_secret }}
+      {{- end }}
+    files:
+      /app/haiku.rag.yaml: file://haiku-config
+    {{- if $endpoint_token_secret }}
+    env:
+      - RAG_ENDPOINT_TOKEN={{ $endpoint_token_secret }}
+    {{- end }}
+    mounts:
+      /data:
+        volume: data
+    resource:
+      cpu:
+        cores: {{ .McpCores }}
+      memory:
+        size: {{ $mcp_memory }}
+    network:
+      ports:
+        - name: mcp
+          port: {{ $mcp_port }}
+          protocol: tcp
+      endpoints:
+        - name: mcp
+          port-name: mcp
+          protocol: http
+          type: subdomain
+          scope: {{ $scope }}
+          annotations:
+            ciq.com/api: mcp
+    script: |
+      #!/bin/sh
+      set -e
+      {{- if not $read_only }}
+      haiku-rag --config /app/haiku.rag.yaml init
+      {{- end }}
+      exec haiku-rag --config /app/haiku.rag.yaml {{ if $read_only }}--read-only {{ end }}mcp --host 0.0.0.0 --port {{ $mcp_port }}
+    readiness-probe:
+      tcp-socket:
+        port: {{ $mcp_port }}
+      initial-delay-seconds: 15
+      period-seconds: 10
+      timeout-seconds: 5
+      failure-threshold: 30
+      success-threshold: 1

--- a/applications/rag/values.yaml
+++ b/applications/rag/values.yaml
@@ -1,0 +1,104 @@
+values:
+  - name: Endpoint
+    display_name: >-
+      Base URL of an OpenAI-compatible endpoint serving the embedding model (and the
+      generation model, if set) -- e.g. the vllm catalog entry's endpoint URL. When
+      empty the services start but ingestion and search fail with a provider error;
+      start a new workflow with endpoint set for real use.
+    string_value: ""
+    display_category: Models
+  - name: EmbeddingModel
+    display_name: >-
+      Embedding model name served by the endpoint. The corpus is permanently bound to
+      this model: changing it against an existing corpus fails at startup (rebuild
+      with 'haiku-rag rebuild --set-embedder' to migrate).
+    string_value: nomic-embed-text
+    display_category: Models
+  - name: EmbeddingDim
+    display_name: Vector dimension of the embedding model.
+    uint_value: 768
+    display_category: Models
+  - name: GenerationModel
+    display_name: >-
+      Generation model name for the ask_question tool. Optional; when empty,
+      ask_question is not usable and retrieval tools are unaffected.
+    string_value: ""
+    display_category: Models
+  - name: EndpointTokenSecret
+    display_name: >-
+      Fuzzball secret (secret://user/<name>) holding the bearer token for the model
+      endpoint; injected at runtime and never stored in the rendered definition.
+      Preferred over EndpointToken for real credentials.
+    secret_value:
+      reference: ""
+    display_category: Models
+  - name: EndpointToken
+    display_name: >-
+      Bearer token for the model endpoint, stored in plain text in the rendered
+      definition (prefer EndpointTokenSecret). When both are empty, the workflow's
+      injected FB_TOKEN is used -- correct when the endpoint is another Fuzzball
+      workflow endpoint (e.g. the vllm entry) in your scope.
+    string_value: ""
+    display_category: Models
+
+  - name: ReadOnly
+    display_name: >-
+      When true (default), the MCP surface exposes retrieval only and ingestion runs
+      through a separate ingester service (async jobs API + watched inbox directory on
+      the volume). When false, no ingester runs and the MCP surface also exposes
+      document management tools.
+    bool_value: true
+    display_category: Access
+  - name: Scope
+    display_name: "Authorization scope of the service endpoints: user, group, organization, or public."
+    string_value: group
+    display_category: Access
+
+  - name: Volume
+    display_name: >-
+      Volume holding the corpus and index: 'ephemeral' (default; evaluation only --
+      cancelling the workflow destroys the corpus) or the name of an existing
+      persistent volume. Mounted at /data.
+    string_value: ephemeral
+    display_category: Storage
+
+  - name: ChunkSize
+    display_name: >-
+      Chunk size (tokens) for document splitting. Corpus-specific: raise for long-form
+      context, lower for precise fact retrieval. Changing it affects newly ingested
+      documents only.
+    uint_value: 256
+    display_category: Ingestion
+
+  - name: McpCores
+    display_name: CPU cores for the MCP service.
+    uint_value: 2
+    display_category: Resources
+  - name: McpMemory
+    display_name: Memory for the MCP service.
+    string_value: 4GiB
+    display_category: Resources
+  - name: IngesterCores
+    display_name: CPU cores for the ingester service (document parsing is CPU-heavy).
+    uint_value: 4
+    display_category: Resources
+  - name: IngesterMemory
+    display_name: Memory for the ingester service.
+    string_value: 8GiB
+    display_category: Resources
+
+  - name: Image
+    display_name: >-
+      haiku.rag container image, built from this entry's definition_files/haiku-rag.def
+      by the catalog's container CI; must bundle the full package, the ingester extra,
+      and pre-downloaded parsing models for air-gapped operation.
+    string_value: oras://ghcr.io/ctrliq/ciq-fuzzball-catalog/rag-haiku-rag:0.78.0-0-amd64
+    display_category: Versions
+  - name: ImageSecret
+    display_name: >-
+      Fuzzball image secret (secret://user/<name>, type image with username/password
+      and trusted-domains) for pulling the haiku.rag image from a private registry.
+      Leave empty for public registries.
+    secret_value:
+      reference: ""
+    display_category: Versions

--- a/applications/rag/values.yaml
+++ b/applications/rag/values.yaml
@@ -35,9 +35,12 @@ values:
   - name: EndpointToken
     display_name: >-
       Bearer token for the model endpoint, stored in plain text in the rendered
-      definition (prefer EndpointTokenSecret). When both are empty, the workflow's
-      injected FB_TOKEN is used -- correct when the endpoint is another Fuzzball
-      workflow endpoint (e.g. the vllm entry) in your scope.
+      definition (prefer EndpointTokenSecret). For a Fuzzball workflow endpoint
+      (e.g. the vllm entry), mint one with 'fuzzball workflow endpoints
+      generate-token <endpoint-id> --expiration <lifetime>' -- size the lifetime
+      to this service's lifetime; the default is short. Requires Endpoint. When
+      both token values are empty and an endpoint is set, a placeholder is sent
+      (fine for endpoints that ignore auth).
     string_value: ""
     display_category: Models
 
@@ -50,8 +53,13 @@ values:
     bool_value: true
     display_category: Access
   - name: Scope
-    display_name: "Authorization scope of the service endpoints: user, group, organization, or public."
+    display_name: >-
+      Authorization scope of the service endpoints. With 'public', the ingest
+      jobs API is protected only by the generated token in the rendered
+      definition.
     string_value: group
+    options_input:
+      options: [user, group, organization, public]
     display_category: Access
 
   - name: Volume


### PR DESCRIPTION
rag — RAG corpus service catalog entry (FUZZ-8338)

Adds a workflow-catalog entry for a retrieval-augmented-generation corpus service built on haiku.rag: document ingestion (PDF/DOCX/PPTX/HTML/text, including OCR for scanned PDFs), hybrid vector + full-text search with citation metadata, and retrieval exposed as MCP tools over streamable HTTP. The corpus is embedded LanceDB on the workflow's volume — no database service to operate.

Architecture

- Default (ReadOnly=true): two services sharing the volume — an ingester (sole LanceDB writer; async job queue with retry/DLQ, watched /data/inbox directory, jobs-monitoring API) and a read-only mcp service, start-ordered via depends-on + readiness probe so the writer initializes the DB before the reader opens it. ReadOnly=false collapses to a single writable MCP service.
- Models are remote: embeddings (and optional generation) are served by any OpenAI-compatible Endpoint — typically the vllm entry. Document parsing is fully in-process with models baked into the image, so the workflow needs no egress beyond the configured endpoint (air-gap friendly; HF_HUB_OFFLINE=1).
- Auth: cross-entry composition uses an endpoint token (fuzzball workflow endpoints generate-token <endpoint-id> --expiration <lifetime>) passed via the EndpointTokenSecret secret reference — injected as env, never stored in the rendered definition. A credential set without an endpoint fails at render (prevents sending a real token to the OpenAI default URL).
- TLS: service scripts build a merged CA bundle (certifi + the node trust store mounted by the platform) and export SSL_CERT_FILE, since Python TLS stacks can't use the platform's SSL_CERT_DIR injection (unhashed cert dir).

Image

Built by this repo's container CI from applications/rag/definition_files/haiku-rag.def (rag-haiku-rag:0.78.0-0-<arch>): haiku.rag 0.78.0 + ingester extra, CPU-only torch, baked docling/OCR parsing models, and a build-anchored patch adding analysis.enabled to gate the code-execution analyze MCP tool off (being submitted upstream; the entry disables it in both modes). The build fails rather than ships if the patch anchor drifts or the model bake is incomplete.

Testing

Validated end-to-end on a live cluster composed against the vllm entry (real GPU serving BAAI/bge-small-en-v1.5):

- Inbox ingestion of all five formats, including OCR from the baked models with zero downloads; retry/backoff + circuit breaker observed under induced failures; unchanged re-adds no-op via upsert.
- MCP through the endpoint proxy: retrieval-only tool surface (no analyze, no write tools), search results with uri/page/heading citations.
- Cancel/restart on the same persistent volume: corpus intact, no re-ingest.
- Embedding-identity guard: restarting with a different EmbeddingDim fails at startup with ConfigMismatchError naming the conflict and the haiku-rag rebuild remediation.

Also adds the PascalCase value-naming convention to CLAUDE.md/StyleGuide.md (per review feedback on the vllm entry).