### PR TITLE
FUZZ-8341: OpenCode coding agent catalog entry

### DIFF
--- a/applications/opencode/metadata.md
+++ b/applications/opencode/metadata.md
@@ -29,19 +29,26 @@ that is its `Model` value without the `hf://` prefix.
 ## Attaching to the model
 
 With the default `EndpointAuth=fuzzball-token`, the workflow authenticates to the
-model endpoint itself: a short job mints an endpoint access token using this
-workflow's own injected identity, so no user credential is stored anywhere in the
-definition. Because the Fuzzball endpoint proxy consumes the `Authorization`
+model endpoint itself: at startup the server mints an endpoint access token using
+this workflow's own injected identity, so no user credential is stored anywhere in
+the definition. Because the Fuzzball endpoint proxy consumes the `Authorization`
 header on any endpoint whose scope is not public, the model's own key (`ApiKey`
 or `ApiKeySecret`) is sent in the `x-litellm-api-key` header, which LiteLLM
 v1.97.0 and later honour and the proxy leaves untouched.
 
 Set `EndpointAuth=api-key` for a public Fuzzball endpoint or a third-party API,
-where the key is sent as the bearer token and nothing is minted.
+where the key is sent as the bearer token and nothing is minted. A public
+endpoint needs no token and the server refuses to mint one for it, so
+`fuzzball-token` against a public endpoint stops the workflow with that message.
 
-The minted token is not renewed. `TokenLifetime` therefore bounds how long the
-server keeps working, up to the seven days the server will grant; restart the
-workflow to mint a fresh one.
+The token is minted by the service itself rather than a preparatory job, because
+the server grants an endpoint token no more lifetime than the calling workflow
+token has left: a job's token lives only as long as the job, while a service
+without a walltime holds one for seven days. It is minted once and never renewed,
+so `TokenLifetime` clamped to that seven days bounds how long the agent can reach
+the model. When it lapses the agent starts failing against the model while the
+server itself stays healthy -- the readiness probe never touches the endpoint --
+so restart the workflow to mint a fresh one.
 
 ## Reaching the server
 
@@ -49,20 +56,25 @@ The service publishes one endpoint serving both an HTTP API and a web
 application. How you reach it depends on `ServiceScope`, and the choice is not
 symmetric:
 
-- At `user`, `group`, or `organization` scope, requests need a Fuzzball
-  credential: an [endpoint access
+- At `user`, `group`, or `organization` scope, requests through the endpoint URL
+  need a Fuzzball credential: an [endpoint access
   token](https://ui.stable.fuzzball.ciq.dev/docs/advanced-features/workflow-endpoints/)
   for API clients, or a browser session for the web application.
-- At `public` scope, Fuzzball performs no authentication and the server's own
-  basic-auth password -- generated at submit time and printed by the
-  `show-server` job -- is the only barrier. This is the only scope a local
-  `opencode attach <url> -p <password>` can use, because attach sends basic-auth
-  credentials in the `Authorization` header that a non-public endpoint's proxy
-  consumes.
+- At `public` scope, Fuzzball performs no authentication of its own.
+
+The server always enforces a basic-auth password, generated at submit time and
+printed by the `show-server` job. That is not redundant with the endpoint scope: a
+plain service binds its port on the node it runs on, so the server is reachable
+directly at that address with no proxy in front of it, whatever the scope says. At
+`public` scope the password is the only barrier at all.
+
+`opencode attach <url> -p <password>` therefore works from outside the cluster
+only at `public` scope: attach sends its credentials in the `Authorization` header,
+which a non-public endpoint's proxy consumes.
 
 Anyone who reaches the server can run shell commands and edit files inside the
-container, so treat the endpoint scope as the security boundary and prefer the
-narrowest one that fits.
+container, so prefer the narrowest scope that fits and treat the password as a
+real credential.
 
 ## Known limitations
 

--- a/applications/opencode/metadata.md
+++ b/applications/opencode/metadata.md
@@ -78,12 +78,11 @@ narrowest one that fits.
   entry, pass the appropriate flags in `ExtraArgs` (for example
   `--tool-call-parser openai --enable-auto-tool-choice` for gpt-oss models).
   Without them the agent can converse but cannot read or edit files.
-- *Private-CA clusters.* OpenCode is a Bun binary: it reads
-  `NODE_EXTRA_CA_CERTS` and ignores `SSL_CERT_DIR`. This entry points it at the
-  node trust store mounted into workflow containers when that is present, and
-  otherwise at `ClusterCASecret`. On a cluster that predates the mounted trust
-  store, leaving `ClusterCASecret` empty means the agent cannot reach the model
-  endpoint over TLS.
+- *Private-CA clusters.* Reaching a Fuzzball endpoint over TLS relies on the node
+  trust store that Fuzzball bind-mounts into workflow containers, so this entry
+  needs a cluster new enough to provide it. OpenCode is a Bun binary and ignores
+  the injected `SSL_CERT_DIR`, so the entry points `NODE_EXTRA_CA_CERTS` at
+  `root-ca.crt` in that mount instead.
 
 ## Storage
 

--- a/applications/opencode/metadata.md
+++ b/applications/opencode/metadata.md
@@ -1,0 +1,92 @@
+# Copyright 2026 CIQ, Inc. All rights reserved.
+---
+id: "ciq/ml_and_ai/opencode"
+name: "opencode"
+category: "ML_AND_AI"
+tags:
+- coding agent
+- LLM
+- OpenAI API
+- development
+---
+This workflow runs [OpenCode](https://opencode.ai), a coding agent, as a
+Fuzzball service already wired to a model served on the cluster. The agent's
+files, sessions, and message history live on the workflow's volume, and the
+model is reached over an OpenAI-compatible endpoint such as the one published by
+the `vllm` or `litellm` entries.
+
+```
+fuzzball workflow catalog start opencode --values Endpoint=https://<endpoint-url>,Model=openai/gpt-oss-20b,ApiKey=sk-...
+fuzzball workflow catalog start opencode --values Endpoint=https://<endpoint-url>,Model=openai/gpt-oss-20b,ApiKeySecret=secret://user/litellm-key
+fuzzball workflow catalog start opencode --values Endpoint=https://<endpoint-url>,Model=openai/gpt-oss-20b,ApiKey=sk-...,ServiceScope=public
+```
+
+Get the endpoint URL of the model workflow with `fuzzball workflow endpoints
+list`, and its LiteLLM key from its definition (`fuzzball workflow get
+<workflow id>`). `Model` is the name the endpoint serves; for the `vllm` entry
+that is its `Model` value without the `hf://` prefix.
+
+## Attaching to the model
+
+With the default `EndpointAuth=fuzzball-token`, the workflow authenticates to the
+model endpoint itself: a short job mints an endpoint access token using this
+workflow's own injected identity, so no user credential is stored anywhere in the
+definition. Because the Fuzzball endpoint proxy consumes the `Authorization`
+header on any endpoint whose scope is not public, the model's own key (`ApiKey`
+or `ApiKeySecret`) is sent in the `x-litellm-api-key` header, which LiteLLM
+v1.97.0 and later honour and the proxy leaves untouched.
+
+Set `EndpointAuth=api-key` for a public Fuzzball endpoint or a third-party API,
+where the key is sent as the bearer token and nothing is minted.
+
+The minted token is not renewed. `TokenLifetime` therefore bounds how long the
+server keeps working, up to the seven days the server will grant; restart the
+workflow to mint a fresh one.
+
+## Reaching the server
+
+The service publishes one endpoint serving both an HTTP API and a web
+application. How you reach it depends on `ServiceScope`, and the choice is not
+symmetric:
+
+- At `user`, `group`, or `organization` scope, requests need a Fuzzball
+  credential: an [endpoint access
+  token](https://ui.stable.fuzzball.ciq.dev/docs/advanced-features/workflow-endpoints/)
+  for API clients, or a browser session for the web application.
+- At `public` scope, Fuzzball performs no authentication and the server's own
+  basic-auth password -- generated at submit time and printed by the
+  `show-server` job -- is the only barrier. This is the only scope a local
+  `opencode attach <url> -p <password>` can use, because attach sends basic-auth
+  credentials in the `Authorization` header that a non-public endpoint's proxy
+  consumes.
+
+Anyone who reaches the server can run shell commands and edit files inside the
+container, so treat the endpoint scope as the security boundary and prefer the
+narrowest one that fits.
+
+## Known limitations
+
+- *The web application cannot select this model.* As of OpenCode 1.18.23 a
+  provider defined in configuration appears in the server's v1 API but not in the
+  v2 API that the bundled web application queries, so the model picker offers only
+  OpenCode's own hosted models. Drive the server through the v1 session API
+  (`POST /session`, then `POST /session/{id}/message` with
+  `{"model":{"providerID":"fuzzball","modelID":"<Model>"},"parts":[...]}`) or
+  attach a local client.
+- *Tool calling depends on the serving side.* Agentic work needs a model that
+  supports tool calls and a server configured to parse them; with the `vllm`
+  entry, pass the appropriate flags in `ExtraArgs` (for example
+  `--tool-call-parser openai --enable-auto-tool-choice` for gpt-oss models).
+  Without them the agent can converse but cannot read or edit files.
+- *Private-CA clusters.* OpenCode is a Bun binary: it reads
+  `NODE_EXTRA_CA_CERTS` and ignores `SSL_CERT_DIR`. This entry points it at the
+  node trust store mounted into workflow containers when that is present, and
+  otherwise at `ClusterCASecret`. On a cluster that predates the mounted trust
+  store, leaving `ClusterCASecret` empty means the agent cannot reach the model
+  endpoint over TLS.
+
+## Storage
+
+`Volume` defaults to `ephemeral`, which destroys the workspace, the session
+history, and any work in progress when the workflow stops. Name an existing
+persistent volume to keep them. The working directory is `/data/workspace`.

--- a/applications/opencode/template.yaml
+++ b/applications/opencode/template.yaml
@@ -1,22 +1,23 @@
 # Copyright 2026 CIQ, Inc. All rights reserved.
 
-{{- $endpoint := trim .Endpoint }}
-{{- if or (contains "\"" $endpoint) (contains "\\" $endpoint) }}
-  {{- fail "Endpoint must not contain quotes or backslashes" }}
+{{- /* Every value below reaches a container env entry or the service script, so
+       each is matched against what it is allowed to contain rather than checked
+       for a few forbidden characters: a newline forges env entries, and '#', '$'
+       or a backtick changes what the script runs. */}}
+
+{{- $endpoint := trimSuffix "/" (trim .Endpoint) }}
+{{- if and $endpoint (not (regexMatch "^https?://[A-Za-z0-9._-]+(:[0-9]+)?(/[A-Za-z0-9._/-]*)?$" $endpoint)) }}
+  {{- fail "Endpoint must be an http(s) URL, e.g. https://endpoint-<id>.endpoints.<cluster domain>" }}
 {{- end }}
-{{- $endpoint = trimSuffix "/" $endpoint }}
 
 {{- $model := trim .Model }}
-{{- if not $model }}
+{{- if not (regexMatch "^[A-Za-z0-9._:/-]+$" $model) }}
   {{- fail "Model must name the model as the endpoint serves it, e.g. openai/gpt-oss-20b" }}
 {{- end }}
-{{- if or (contains "\"" $model) (contains "\\" $model) }}
-  {{- fail "Model must not contain quotes or backslashes" }}
-{{- end }}
 
-{{- $context_size := int .ContextSize }}
+{{- $context_size := int .MaxContextSize }}
 {{- if lt $context_size 1024 }}
-  {{- fail "ContextSize must be at least 1024" }}
+  {{- fail "MaxContextSize must be at least 1024" }}
 {{- end }}
 {{- $output_limit := int .OutputLimit }}
 {{- if lt $output_limit 256 }}
@@ -29,11 +30,14 @@
 {{- end }}
 
 {{- $api_key_secret := trim .ApiKeySecret }}
-{{- $api_key := trim .ApiKey }}
-{{- if or (contains "\"" $api_key) (contains "\\" $api_key) }}
-  {{- fail "ApiKey must not contain quotes or backslashes" }}
+{{- if and $api_key_secret (not (regexMatch "^secret://[A-Za-z0-9._/-]+$" $api_key_secret)) }}
+  {{- fail "ApiKeySecret must be a secret:// reference, e.g. secret://user/litellm-key" }}
 {{- end }}
-{{- if and (eq $auth "api-key") $endpoint (not (or $api_key_secret $api_key)) }}
+{{- $api_key := trim .ApiKey }}
+{{- if and $api_key (not (regexMatch "^[A-Za-z0-9._-]+$" $api_key)) }}
+  {{- fail "ApiKey may contain only letters, digits, '.', '_' and '-'" }}
+{{- end }}
+{{- if and (eq $auth "api-key") (not (or $api_key_secret $api_key)) }}
   {{- fail "EndpointAuth=api-key needs ApiKeySecret or ApiKey" }}
 {{- end }}
 
@@ -48,21 +52,29 @@
 {{- end }}
 
 {{- $volume := trim .Volume }}
-{{- if not $volume }}
+{{- if not (regexMatch "^[A-Za-z0-9._-]+$" $volume) }}
   {{- fail "Volume must be 'ephemeral' or the name of a persistent volume" }}
 {{- end }}
-{{- if or (contains "\"" $volume) (contains "\\" $volume) }}
-  {{- fail "Volume must not contain quotes or backslashes" }}
+
+{{- $memory := trim .Memory }}
+{{- if not (regexMatch "^[0-9]+(\\.[0-9]+)?[KMGT]i?B$" $memory) }}
+  {{- fail "Memory must be a size such as 8GiB" }}
+{{- end }}
+{{- $image := trim .Image }}
+{{- if not (regexMatch "^(docker|oras)://[A-Za-z0-9._@:/-]+$" $image) }}
+  {{- fail "Image must be a docker:// or oras:// container reference" }}
+{{- end }}
+{{- $curl_image := trim .CurlImage }}
+{{- if not (regexMatch "^(docker|oras)://[A-Za-z0-9._@:/-]+$" $curl_image) }}
+  {{- fail "CurlImage must be a docker:// or oras:// container reference" }}
 {{- end }}
 
-{{- /* Minting only makes sense against a Fuzzball endpoint, which this workflow
-       reaches with its own injected identity. */}}
+{{- /* Minting only makes sense against a Fuzzball endpoint, which this service
+       reaches with its own injected identity. It happens in the service rather
+       than a job: the server grants an endpoint token no more lifetime than the
+       calling workflow token has left, and a job's token expires with the job. */}}
 {{- $mint := and (eq $auth "fuzzball-token") (ne $endpoint "") }}
 
-{{- /* The server's basic-auth password. It can only be presented through a
-       public endpoint -- every other scope has the Fuzzball proxy consuming the
-       Authorization header -- so it is set there and nowhere else. Generated as
-       hex from 63-bit randInt draws; slim-sprig has no randAlphaNum. */}}
 {{- $password := printf "%016x%016x" (randInt 0 9223372036854775807) (randInt 0 9223372036854775807) }}
 
 {{- $port := randInt 24001 32000 }}
@@ -80,59 +92,9 @@ volumes:
     {{- end }}
 
 jobs:
-{{- if $mint }}
-  mint-token:
-    image:
-      uri: {{ .CurlImage }}
-    mounts:
-      /data:
-        volume: data
-    env:
-      - ENDPOINT_URL={{ $endpoint }}
-      - TOKEN_TTL={{ $token_lifetime }}
-    script: |
-      #!/bin/sh
-      set -e
-      mkdir -p /data/.auth
-
-      # The endpoint id is the first hostname label of an endpoint URL.
-      host=$(echo "${ENDPOINT_URL}" | sed -e 's#^https\?://##' -e 's#/.*##')
-      endpoint_id=$(echo "${host}" | cut -d. -f1)
-      case "${endpoint_id}" in
-        endpoint-*) ;;
-        *)
-          echo "FATAL: ${ENDPOINT_URL} is not a Fuzzball endpoint URL; use EndpointAuth=api-key" >&2
-          exit 1
-          ;;
-      esac
-
-      curl -sf --cacert {{ $trust_store }} -X POST \
-        -H "Authorization: Bearer ${FB_TOKEN}" \
-        -H "Content-Type: application/json" \
-        -d "{\"expirationSeconds\": ${TOKEN_TTL}}" \
-        "${FB_OPENAPI_URL%/}/v4/endpoints/${endpoint_id}/token" > /data/.auth/token.json
-
-      grep -o '"token":"[^"]*"' /data/.auth/token.json | cut -d'"' -f4 > /data/.auth/endpoint-token
-      if [ ! -s /data/.auth/endpoint-token ]; then
-        echo "FATAL: no token in the mint response" >&2
-        head -c 400 /data/.auth/token.json >&2
-        exit 1
-      fi
-      rm -f /data/.auth/token.json
-      echo "minted an access token for ${endpoint_id}"
-    resource:
-      cpu:
-        cores: 1
-      memory:
-        size: 128MB
-    policy:
-      timeout:
-        execute: 5m
-{{- end }}
-
   show-server:
     image:
-      uri: {{ .CurlImage }}
+      uri: {{ $curl_image }}
     depends-on:
       - name: opencode
         status: RUNNING
@@ -142,29 +104,22 @@ jobs:
       echo "Get the server URL with:"
       echo "   fuzzball workflow endpoints list"
       echo ""
-      {{- if eq $scope "public" }}
-      echo "Attach a local OpenCode to it (opencode 1.18 or later):"
-      echo "   opencode attach <server url> -p {{ $password }}"
+      echo "Server password (also in the definition: fuzzball workflow get <workflow id>):"
+      echo "   {{ $password }}"
       echo ""
-      echo "This endpoint is public: the password above is the only thing"
-      echo "protecting a service that can run shell commands. Rotate it by"
-      echo "restarting the workflow."
-      {{- else }}
-      echo "The endpoint scope is {{ $scope }}, so requests need a Fuzzball"
-      echo "credential in the Authorization header:"
+      echo "Attach a local OpenCode (1.18 or later):"
+      echo "   opencode attach <server url> -p {{ $password }}"
+      {{- if ne $scope "public" }}
+      echo ""
+      echo "The endpoint scope is {{ $scope }}, so requests through the endpoint URL"
+      echo "also need a Fuzzball credential in the Authorization header:"
       echo "   fuzzball workflow endpoints generate-token <endpoint id>"
       echo ""
-      echo "Local 'opencode attach' cannot be used at this scope: it sends only"
-      echo "basic-auth credentials, and the endpoint proxy consumes that header."
-      echo "Start this entry with ServiceScope=public to attach a local client."
+      echo "That header is consumed by the endpoint proxy, so 'opencode attach'"
+      echo "works against this scope only from inside the cluster network."
       {{- end }}
       echo ""
       echo "Model configured for this server: fuzzball/{{ $model }}"
-      {{- if not $endpoint }}
-      echo ""
-      echo "WARNING: Endpoint was left empty, so no model is reachable. Start a"
-      echo "new workflow with Endpoint set to an OpenAI-compatible base URL."
-      {{- end }}
     resource:
       cpu:
         cores: 1
@@ -177,16 +132,10 @@ jobs:
 services:
   opencode:
     image:
-      uri: {{ .Image }}
+      uri: {{ $image }}
     mounts:
       /data:
         volume: data
-    {{- if $mint }}
-    depends-on:
-      - name: mint-token
-        status: FINISHED
-        description: "The endpoint access token is minted before the server starts"
-    {{- end }}
     env:
       # The image runs as a different uid under Fuzzball, so every writable path
       # OpenCode uses is redirected onto the volume. HOME is the volume root
@@ -201,9 +150,9 @@ services:
       - OPENCODE_CONFIG=/data/.config/opencode.json
       # The Bun runtime ignores the injected SSL_CERT_DIR.
       - NODE_EXTRA_CA_CERTS={{ $trust_store }}
-      {{- if eq $scope "public" }}
+      # A plain service binds its port on the node, so the endpoint proxy is not
+      # the only way in and the scope alone protects nothing.
       - OPENCODE_SERVER_PASSWORD={{ $password }}
-      {{- end }}
       {{- if $api_key_secret }}
       - MODEL_API_KEY={{ $api_key_secret }}
       {{- else if $api_key }}
@@ -213,14 +162,48 @@ services:
       #!/bin/sh
       set -e
       mkdir -p /data/workspace /data/.config
+      {{- if not $endpoint }}
 
+      echo "FATAL: Endpoint is empty, so no model is reachable. Start this entry" >&2
+      echo "with Endpoint set to an OpenAI-compatible base URL." >&2
+      exit 1
+      {{- end }}
       {{- if $mint }}
-      credential=$(cat /data/.auth/endpoint-token)
+
+      endpoint_id=$(echo "{{ $endpoint }}" | sed -e 's#^https\?://##' -e 's#/.*##' | cut -d. -f1)
+      case "${endpoint_id}" in
+        endpoint-*) ;;
+        *)
+          echo "FATAL: {{ $endpoint }} is not a Fuzzball endpoint URL; use EndpointAuth=api-key" >&2
+          exit 1
+          ;;
+      esac
+      if [ -z "${FB_TOKEN}" ]; then
+        echo "FATAL: no workflow API token was injected, so no endpoint token can be" >&2
+        echo "minted. Use EndpointAuth=api-key with a key for the endpoint." >&2
+        exit 1
+      fi
+
+      minted=$(SSL_CERT_FILE={{ $trust_store }} wget -q -O - \
+        --header="Authorization: Bearer ${FB_TOKEN}" \
+        --header="Content-Type: application/json" \
+        --post-data="{\"expirationSeconds\": {{ $token_lifetime }}}" \
+        "${FB_OPENAPI_URL%/}/v4/endpoints/${endpoint_id}/token" 2> /tmp/mint.err) || {
+        echo "FATAL: could not mint an access token for ${endpoint_id}. A public" >&2
+        echo "endpoint takes no token: use EndpointAuth=api-key instead." >&2
+        cat /tmp/mint.err >&2
+        exit 1
+      }
+      credential=$(echo "${minted}" | grep -o '"token":"[^"]*"' | cut -d'"' -f4)
+      if [ -z "${credential}" ]; then
+        echo "FATAL: no token in the mint response" >&2
+        exit 1
+      fi
       {{- else }}
+
       credential="${MODEL_API_KEY}"
       {{- end }}
 
-      # Written at runtime because the credential is not known at submit time.
       umask 077
       cat > /data/.config/opencode.json <<EOF
       {
@@ -248,6 +231,23 @@ services:
       }
       EOF
 
+      # A rejected credential otherwise surfaces at the user's first prompt: the
+      # readiness probe never touches the model endpoint.
+      if ! {{ if $mint }}SSL_CERT_FILE={{ $trust_store }} {{ end }}wget -q -O /dev/null \
+        --header="Authorization: Bearer ${credential}" \
+      {{- if and $mint (or $api_key_secret $api_key) }}
+        --header="x-litellm-api-key: ${MODEL_API_KEY}" \
+      {{- end }}
+        "{{ $endpoint }}/v1/models" 2> /tmp/probe.err; then
+        if grep -q "40[13]" /tmp/probe.err; then
+          echo "FATAL: the model endpoint rejected these credentials:" >&2
+          cat /tmp/probe.err >&2
+          exit 1
+        fi
+        echo "WARNING: the model endpoint did not answer /v1/models yet:" >&2
+        cat /tmp/probe.err >&2
+      fi
+
       cd /data/workspace
       exec opencode serve --hostname 0.0.0.0 --port {{ $port }} --print-logs
     network:
@@ -263,8 +263,8 @@ services:
           scope: {{ $scope }}
     readiness-probe:
       http-get:
-        # Every unknown path answers 200 with the web app's HTML, so the probe
-        # has to name a real route: this one returns JSON.
+        # Every unknown path answers 200 with the web application's HTML, so the
+        # probe has to name a real route: this one returns JSON.
         path: /global/health
         port: {{ $port }}
         scheme: HTTP
@@ -277,5 +277,5 @@ services:
       cpu:
         cores: {{ .Cores }}
       memory:
-        size: {{ .Memory }}
+        size: {{ $memory }}
     persist: true

--- a/applications/opencode/template.yaml
+++ b/applications/opencode/template.yaml
@@ -98,7 +98,7 @@ jobs:
     depends-on:
       - name: opencode
         status: RUNNING
-        description: "Wait for the server to answer"
+        description: "Print connection details once the server is running"
     script: |
       #!/bin/sh
       echo "Get the server URL with:"
@@ -170,7 +170,7 @@ services:
       {{- end }}
       {{- if $mint }}
 
-      endpoint_id=$(echo "{{ $endpoint }}" | sed -e 's#^https\?://##' -e 's#/.*##' | cut -d. -f1)
+      endpoint_id=$(echo "{{ $endpoint }}" | sed -e 's#^[a-z]*://##' -e 's#/.*##' -e 's#:.*##' | cut -d. -f1)
       case "${endpoint_id}" in
         endpoint-*) ;;
         *)

--- a/applications/opencode/template.yaml
+++ b/applications/opencode/template.yaml
@@ -55,8 +55,6 @@
   {{- fail "Volume must not contain quotes or backslashes" }}
 {{- end }}
 
-{{- $cluster_ca := trim .ClusterCASecret }}
-
 {{- /* Minting only makes sense against a Fuzzball endpoint, which this workflow
        reaches with its own injected identity. */}}
 {{- $mint := and (eq $auth "fuzzball-token") (ne $endpoint "") }}
@@ -92,13 +90,10 @@ jobs:
     env:
       - ENDPOINT_URL={{ $endpoint }}
       - TOKEN_TTL={{ $token_lifetime }}
-      {{- if $cluster_ca }}
-      - CLUSTER_CA_PEM={{ $cluster_ca }}
-      {{- end }}
     script: |
       #!/bin/sh
       set -e
-      mkdir -p /data/auth
+      mkdir -p /data/.auth
 
       # The endpoint id is the first hostname label of an endpoint URL.
       host=$(echo "${ENDPOINT_URL}" | sed -e 's#^https\?://##' -e 's#/.*##')
@@ -111,29 +106,19 @@ jobs:
           ;;
       esac
 
-      # The Fuzzball API is served with the cluster's own CA. Newer clusters
-      # mount the node trust store here; older ones need ClusterCASecret.
-      ca=""
-      if [ -f {{ $trust_store }} ]; then
-        ca="--cacert {{ $trust_store }}"
-      elif [ -n "${CLUSTER_CA_PEM}" ]; then
-        printf '%s\n' "${CLUSTER_CA_PEM}" > /data/auth/cluster-ca.pem
-        ca="--cacert /data/auth/cluster-ca.pem"
-      fi
-
-      curl -sf ${ca} -X POST \
+      curl -sf --cacert {{ $trust_store }} -X POST \
         -H "Authorization: Bearer ${FB_TOKEN}" \
         -H "Content-Type: application/json" \
         -d "{\"expirationSeconds\": ${TOKEN_TTL}}" \
-        "${FB_OPENAPI_URL%/}/v4/endpoints/${endpoint_id}/token" > /data/auth/token.json
+        "${FB_OPENAPI_URL%/}/v4/endpoints/${endpoint_id}/token" > /data/.auth/token.json
 
-      grep -o '"token":"[^"]*"' /data/auth/token.json | cut -d'"' -f4 > /data/auth/endpoint-token
-      if [ ! -s /data/auth/endpoint-token ]; then
+      grep -o '"token":"[^"]*"' /data/.auth/token.json | cut -d'"' -f4 > /data/.auth/endpoint-token
+      if [ ! -s /data/.auth/endpoint-token ]; then
         echo "FATAL: no token in the mint response" >&2
-        head -c 400 /data/auth/token.json >&2
+        head -c 400 /data/.auth/token.json >&2
         exit 1
       fi
-      rm -f /data/auth/token.json
+      rm -f /data/.auth/token.json
       echo "minted an access token for ${endpoint_id}"
     resource:
       cpu:
@@ -204,13 +189,18 @@ services:
     {{- end }}
     env:
       # The image runs as a different uid under Fuzzball, so every writable path
-      # OpenCode uses is redirected onto the volume.
-      - HOME=/data/home
-      - XDG_CONFIG_HOME=/data/home/.config
-      - XDG_DATA_HOME=/data/home/.local/share
-      - XDG_CACHE_HOME=/data/home/.cache
-      - XDG_STATE_HOME=/data/home/.local/state
-      - OPENCODE_CONFIG=/data/home/opencode.json
+      # OpenCode uses is redirected onto the volume. HOME is the volume root
+      # rather than a directory beside the workspace: the web application's
+      # project browser is rooted at HOME, and a workspace outside that tree
+      # cannot be opened at all.
+      - HOME=/data
+      - XDG_CONFIG_HOME=/data/.config
+      - XDG_DATA_HOME=/data/.local/share
+      - XDG_CACHE_HOME=/data/.cache
+      - XDG_STATE_HOME=/data/.local/state
+      - OPENCODE_CONFIG=/data/.config/opencode.json
+      # The Bun runtime ignores the injected SSL_CERT_DIR.
+      - NODE_EXTRA_CA_CERTS={{ $trust_store }}
       {{- if eq $scope "public" }}
       - OPENCODE_SERVER_PASSWORD={{ $password }}
       {{- end }}
@@ -219,34 +209,20 @@ services:
       {{- else if $api_key }}
       - MODEL_API_KEY={{ $api_key }}
       {{- end }}
-      {{- if $cluster_ca }}
-      - CLUSTER_CA_PEM={{ $cluster_ca }}
-      {{- end }}
     script: |
       #!/bin/sh
       set -e
-      mkdir -p /data/home /data/workspace
-
-      # OpenCode is a Bun binary, which reads NODE_EXTRA_CA_CERTS and ignores
-      # SSL_CERT_DIR, so the cluster CA is pointed at by file.
-      if [ -f {{ $trust_store }} ]; then
-        NODE_EXTRA_CA_CERTS={{ $trust_store }}
-        export NODE_EXTRA_CA_CERTS
-      elif [ -n "${CLUSTER_CA_PEM}" ]; then
-        printf '%s\n' "${CLUSTER_CA_PEM}" > /data/home/cluster-ca.pem
-        NODE_EXTRA_CA_CERTS=/data/home/cluster-ca.pem
-        export NODE_EXTRA_CA_CERTS
-      fi
+      mkdir -p /data/workspace /data/.config
 
       {{- if $mint }}
-      credential=$(cat /data/auth/endpoint-token)
+      credential=$(cat /data/.auth/endpoint-token)
       {{- else }}
       credential="${MODEL_API_KEY}"
       {{- end }}
 
       # Written at runtime because the credential is not known at submit time.
       umask 077
-      cat > /data/home/opencode.json <<EOF
+      cat > /data/.config/opencode.json <<EOF
       {
         "\$schema": "https://opencode.ai/config.json",
         "provider": {

--- a/applications/opencode/template.yaml
+++ b/applications/opencode/template.yaml
@@ -1,0 +1,305 @@
+# Copyright 2026 CIQ, Inc. All rights reserved.
+
+{{- $endpoint := trim .Endpoint }}
+{{- if or (contains "\"" $endpoint) (contains "\\" $endpoint) }}
+  {{- fail "Endpoint must not contain quotes or backslashes" }}
+{{- end }}
+{{- $endpoint = trimSuffix "/" $endpoint }}
+
+{{- $model := trim .Model }}
+{{- if not $model }}
+  {{- fail "Model must name the model as the endpoint serves it, e.g. openai/gpt-oss-20b" }}
+{{- end }}
+{{- if or (contains "\"" $model) (contains "\\" $model) }}
+  {{- fail "Model must not contain quotes or backslashes" }}
+{{- end }}
+
+{{- $context_size := int .ContextSize }}
+{{- if lt $context_size 1024 }}
+  {{- fail "ContextSize must be at least 1024" }}
+{{- end }}
+{{- $output_limit := int .OutputLimit }}
+{{- if lt $output_limit 256 }}
+  {{- fail "OutputLimit must be at least 256" }}
+{{- end }}
+
+{{- $auth := lower (trim .EndpointAuth) }}
+{{- if not (has $auth (list "fuzzball-token" "api-key")) }}
+  {{- fail "EndpointAuth must be one of: fuzzball-token, api-key" }}
+{{- end }}
+
+{{- $api_key_secret := trim .ApiKeySecret }}
+{{- $api_key := trim .ApiKey }}
+{{- if or (contains "\"" $api_key) (contains "\\" $api_key) }}
+  {{- fail "ApiKey must not contain quotes or backslashes" }}
+{{- end }}
+{{- if and (eq $auth "api-key") $endpoint (not (or $api_key_secret $api_key)) }}
+  {{- fail "EndpointAuth=api-key needs ApiKeySecret or ApiKey" }}
+{{- end }}
+
+{{- $token_lifetime := int .TokenLifetime }}
+{{- if lt $token_lifetime 300 }}
+  {{- fail "TokenLifetime must be at least 300 seconds" }}
+{{- end }}
+
+{{- $scope := lower (trim .ServiceScope) }}
+{{- if not (has $scope (list "user" "group" "organization" "public")) }}
+  {{- fail "ServiceScope must be one of: user, group, organization, public" }}
+{{- end }}
+
+{{- $volume := trim .Volume }}
+{{- if not $volume }}
+  {{- fail "Volume must be 'ephemeral' or the name of a persistent volume" }}
+{{- end }}
+{{- if or (contains "\"" $volume) (contains "\\" $volume) }}
+  {{- fail "Volume must not contain quotes or backslashes" }}
+{{- end }}
+
+{{- $cluster_ca := trim .ClusterCASecret }}
+
+{{- /* Minting only makes sense against a Fuzzball endpoint, which this workflow
+       reaches with its own injected identity. */}}
+{{- $mint := and (eq $auth "fuzzball-token") (ne $endpoint "") }}
+
+{{- /* The server's basic-auth password. It can only be presented through a
+       public endpoint -- every other scope has the Fuzzball proxy consuming the
+       Authorization header -- so it is set there and nowhere else. Generated as
+       hex from 63-bit randInt draws; slim-sprig has no randAlphaNum. */}}
+{{- $password := printf "%016x%016x" (randInt 0 9223372036854775807) (randInt 0 9223372036854775807) }}
+
+{{- $port := randInt 24001 32000 }}
+{{- $trust_store := "/run/fuzzball-substrate/trusted-certs/root-ca.crt" }}
+
+version: v4
+
+volumes:
+  data:
+    {{- if eq (lower $volume) "ephemeral" }}
+    use: ephemeral
+    {{- else }}
+    use: persistent
+    name: "{{ $volume }}"
+    {{- end }}
+
+jobs:
+{{- if $mint }}
+  mint-token:
+    image:
+      uri: {{ .CurlImage }}
+    mounts:
+      /data:
+        volume: data
+    env:
+      - ENDPOINT_URL={{ $endpoint }}
+      - TOKEN_TTL={{ $token_lifetime }}
+      {{- if $cluster_ca }}
+      - CLUSTER_CA_PEM={{ $cluster_ca }}
+      {{- end }}
+    script: |
+      #!/bin/sh
+      set -e
+      mkdir -p /data/auth
+
+      # The endpoint id is the first hostname label of an endpoint URL.
+      host=$(echo "${ENDPOINT_URL}" | sed -e 's#^https\?://##' -e 's#/.*##')
+      endpoint_id=$(echo "${host}" | cut -d. -f1)
+      case "${endpoint_id}" in
+        endpoint-*) ;;
+        *)
+          echo "FATAL: ${ENDPOINT_URL} is not a Fuzzball endpoint URL; use EndpointAuth=api-key" >&2
+          exit 1
+          ;;
+      esac
+
+      # The Fuzzball API is served with the cluster's own CA. Newer clusters
+      # mount the node trust store here; older ones need ClusterCASecret.
+      ca=""
+      if [ -f {{ $trust_store }} ]; then
+        ca="--cacert {{ $trust_store }}"
+      elif [ -n "${CLUSTER_CA_PEM}" ]; then
+        printf '%s\n' "${CLUSTER_CA_PEM}" > /data/auth/cluster-ca.pem
+        ca="--cacert /data/auth/cluster-ca.pem"
+      fi
+
+      curl -sf ${ca} -X POST \
+        -H "Authorization: Bearer ${FB_TOKEN}" \
+        -H "Content-Type: application/json" \
+        -d "{\"expirationSeconds\": ${TOKEN_TTL}}" \
+        "${FB_OPENAPI_URL%/}/v4/endpoints/${endpoint_id}/token" > /data/auth/token.json
+
+      grep -o '"token":"[^"]*"' /data/auth/token.json | cut -d'"' -f4 > /data/auth/endpoint-token
+      if [ ! -s /data/auth/endpoint-token ]; then
+        echo "FATAL: no token in the mint response" >&2
+        head -c 400 /data/auth/token.json >&2
+        exit 1
+      fi
+      rm -f /data/auth/token.json
+      echo "minted an access token for ${endpoint_id}"
+    resource:
+      cpu:
+        cores: 1
+      memory:
+        size: 128MB
+    policy:
+      timeout:
+        execute: 5m
+{{- end }}
+
+  show-server:
+    image:
+      uri: {{ .CurlImage }}
+    depends-on:
+      - name: opencode
+        status: RUNNING
+        description: "Wait for the server to answer"
+    script: |
+      #!/bin/sh
+      echo "Get the server URL with:"
+      echo "   fuzzball workflow endpoints list"
+      echo ""
+      {{- if eq $scope "public" }}
+      echo "Attach a local OpenCode to it (opencode 1.18 or later):"
+      echo "   opencode attach <server url> -p {{ $password }}"
+      echo ""
+      echo "This endpoint is public: the password above is the only thing"
+      echo "protecting a service that can run shell commands. Rotate it by"
+      echo "restarting the workflow."
+      {{- else }}
+      echo "The endpoint scope is {{ $scope }}, so requests need a Fuzzball"
+      echo "credential in the Authorization header:"
+      echo "   fuzzball workflow endpoints generate-token <endpoint id>"
+      echo ""
+      echo "Local 'opencode attach' cannot be used at this scope: it sends only"
+      echo "basic-auth credentials, and the endpoint proxy consumes that header."
+      echo "Start this entry with ServiceScope=public to attach a local client."
+      {{- end }}
+      echo ""
+      echo "Model configured for this server: fuzzball/{{ $model }}"
+      {{- if not $endpoint }}
+      echo ""
+      echo "WARNING: Endpoint was left empty, so no model is reachable. Start a"
+      echo "new workflow with Endpoint set to an OpenAI-compatible base URL."
+      {{- end }}
+    resource:
+      cpu:
+        cores: 1
+      memory:
+        size: 128MB
+    policy:
+      timeout:
+        execute: 10m
+
+services:
+  opencode:
+    image:
+      uri: {{ .Image }}
+    mounts:
+      /data:
+        volume: data
+    {{- if $mint }}
+    depends-on:
+      - name: mint-token
+        status: FINISHED
+        description: "The endpoint access token is minted before the server starts"
+    {{- end }}
+    env:
+      # The image runs as a different uid under Fuzzball, so every writable path
+      # OpenCode uses is redirected onto the volume.
+      - HOME=/data/home
+      - XDG_CONFIG_HOME=/data/home/.config
+      - XDG_DATA_HOME=/data/home/.local/share
+      - XDG_CACHE_HOME=/data/home/.cache
+      - XDG_STATE_HOME=/data/home/.local/state
+      - OPENCODE_CONFIG=/data/home/opencode.json
+      {{- if eq $scope "public" }}
+      - OPENCODE_SERVER_PASSWORD={{ $password }}
+      {{- end }}
+      {{- if $api_key_secret }}
+      - MODEL_API_KEY={{ $api_key_secret }}
+      {{- else if $api_key }}
+      - MODEL_API_KEY={{ $api_key }}
+      {{- end }}
+      {{- if $cluster_ca }}
+      - CLUSTER_CA_PEM={{ $cluster_ca }}
+      {{- end }}
+    script: |
+      #!/bin/sh
+      set -e
+      mkdir -p /data/home /data/workspace
+
+      # OpenCode is a Bun binary, which reads NODE_EXTRA_CA_CERTS and ignores
+      # SSL_CERT_DIR, so the cluster CA is pointed at by file.
+      if [ -f {{ $trust_store }} ]; then
+        NODE_EXTRA_CA_CERTS={{ $trust_store }}
+        export NODE_EXTRA_CA_CERTS
+      elif [ -n "${CLUSTER_CA_PEM}" ]; then
+        printf '%s\n' "${CLUSTER_CA_PEM}" > /data/home/cluster-ca.pem
+        NODE_EXTRA_CA_CERTS=/data/home/cluster-ca.pem
+        export NODE_EXTRA_CA_CERTS
+      fi
+
+      {{- if $mint }}
+      credential=$(cat /data/auth/endpoint-token)
+      {{- else }}
+      credential="${MODEL_API_KEY}"
+      {{- end }}
+
+      # Written at runtime because the credential is not known at submit time.
+      umask 077
+      cat > /data/home/opencode.json <<EOF
+      {
+        "\$schema": "https://opencode.ai/config.json",
+        "provider": {
+          "fuzzball": {
+            "npm": "@ai-sdk/openai-compatible",
+            "name": "Fuzzball",
+            "options": {
+              "baseURL": "{{ $endpoint }}/v1",
+              "apiKey": "${credential}"
+      {{- if and $mint (or $api_key_secret $api_key) }}
+              ,"headers": { "x-litellm-api-key": "${MODEL_API_KEY}" }
+      {{- end }}
+            },
+            "models": {
+              "{{ $model }}": {
+                "name": "{{ $model }} on Fuzzball",
+                "limit": { "context": {{ $context_size }}, "output": {{ $output_limit }} }
+              }
+            }
+          }
+        },
+        "model": "fuzzball/{{ $model }}"
+      }
+      EOF
+
+      cd /data/workspace
+      exec opencode serve --hostname 0.0.0.0 --port {{ $port }} --print-logs
+    network:
+      ports:
+        - name: http
+          port: {{ $port }}
+          protocol: tcp
+      endpoints:
+        - name: server
+          port-name: http
+          protocol: http
+          type: subdomain
+          scope: {{ $scope }}
+    readiness-probe:
+      http-get:
+        # Every unknown path answers 200 with the web app's HTML, so the probe
+        # has to name a real route: this one returns JSON.
+        path: /global/health
+        port: {{ $port }}
+        scheme: HTTP
+      initial-delay-seconds: 10
+      period-seconds: 10
+      timeout-seconds: 5
+      failure-threshold: 30
+      success-threshold: 1
+    resource:
+      cpu:
+        cores: {{ .Cores }}
+      memory:
+        size: {{ .Memory }}
+    persist: true

--- a/applications/opencode/values.yaml
+++ b/applications/opencode/values.yaml
@@ -2,8 +2,8 @@ values:
   - name: Endpoint
     display_name: >-
       Base URL of the OpenAI-compatible endpoint to code against, e.g. the endpoint URL of a
-      vllm or litellm workflow (no /v1 suffix). When empty the server still starts, but no
-      model is usable; start a new workflow with the endpoint set.
+      vllm or litellm workflow (no /v1 suffix). Required: left empty, the workflow stops at
+      once rather than running an agent with no model behind it.
     string_value: ""
     display_category: Model
   - name: Model
@@ -12,7 +12,7 @@ values:
       the hf:// prefix, e.g. openai/gpt-oss-20b.
     string_value: openai/gpt-oss-20b
     display_category: Model
-  - name: ContextSize
+  - name: MaxContextSize
     display_name: >-
       Maximum input tokens the model accepts. OpenCode tracks remaining context against this,
       so a value above what the endpoint serves produces requests the model rejects. Match the
@@ -54,20 +54,22 @@ values:
   - name: TokenLifetime
     display_name: >-
       Seconds the minted endpoint access token is requested for, when
-      EndpointAuth=fuzzball-token. The token is minted once at start and not renewed, so this
-      bounds how long the server keeps working; restart the workflow to mint a fresh one. The
-      server caps the grant at its own limit, at most 7 days.
+      EndpointAuth=fuzzball-token. The grant is clamped to what is left of this workflow's own
+      API token, which for a service with no walltime is 7 days from workflow start. The token
+      is minted once at startup and not renewed, so it bounds how long the agent can reach the
+      model; restart the workflow for a fresh one.
     uint_value: 604800
     display_category: Model
 
   - name: ServiceScope
     display_name: >-
       Who can reach the OpenCode server endpoint. Anyone who reaches it can run shell commands
-      and edit files in this workflow's container, so keep it as narrow as the people using it.
-      Note 'public' is served without any Fuzzball authentication, leaving the generated server
-      password as the only barrier -- but it is the only scope a local 'opencode attach' can
-      use, because the Fuzzball endpoint proxy consumes the Authorization header that attach's
-      basic-auth credentials would travel in.
+      and edit files in this workflow's container. The server always enforces its own basic-auth
+      password, printed by the show-server job, because the service also listens on its node's
+      port where no endpoint proxy sits in front of it. At 'public' scope that password is the
+      only barrier, and it is also the only scope a local 'opencode attach' can reach from
+      outside the cluster: at every other scope the endpoint proxy consumes the Authorization
+      header attach's credentials travel in.
     string_value: user
     options_input:
       options: [user, group, organization, public]
@@ -92,10 +94,13 @@ values:
     display_category: Resources
 
   - name: Image
-    display_name: OpenCode container image.
+    display_name: >-
+      OpenCode container image. The default is the image the OpenCode project publishes itself;
+      it is not built or mirrored by this repository, so a deployment that will not run
+      third-party images should point this at its own build.
     string_value: docker://ghcr.io/anomalyco/opencode:1.18.23
     display_category: Versions
   - name: CurlImage
-    display_name: Image used by the short-lived job that mints the endpoint access token.
+    display_name: Image used by the short-lived job that prints how to reach the server.
     string_value: docker://curlimages/curl:8.17.0
     display_category: Versions

--- a/applications/opencode/values.yaml
+++ b/applications/opencode/values.yaml
@@ -82,16 +82,6 @@ values:
     string_value: ephemeral
     display_category: Storage
 
-  - name: ClusterCASecret
-    display_name: >-
-      Fuzzball secret holding the cluster's PEM certificate authority. Needed only on clusters
-      that serve a private CA and predate the node trust store being mounted into workflow
-      containers; on newer clusters leave this empty and the mounted trust store is used.
-      Without either, OpenCode cannot reach a Fuzzball endpoint over TLS.
-    secret_value:
-      reference: ""
-    display_category: Access
-
   - name: Cores
     display_name: CPU cores for the OpenCode server.
     uint_value: 4

--- a/applications/opencode/values.yaml
+++ b/applications/opencode/values.yaml
@@ -1,0 +1,111 @@
+values:
+  - name: Endpoint
+    display_name: >-
+      Base URL of the OpenAI-compatible endpoint to code against, e.g. the endpoint URL of a
+      vllm or litellm workflow (no /v1 suffix). When empty the server still starts, but no
+      model is usable; start a new workflow with the endpoint set.
+    string_value: ""
+    display_category: Model
+  - name: Model
+    display_name: >-
+      Model name as the endpoint serves it. For the vllm entry this is its Model value without
+      the hf:// prefix, e.g. openai/gpt-oss-20b.
+    string_value: openai/gpt-oss-20b
+    display_category: Model
+  - name: ContextSize
+    display_name: >-
+      Maximum input tokens the model accepts. OpenCode tracks remaining context against this,
+      so a value above what the endpoint serves produces requests the model rejects. Match the
+      serving entry (the vllm entry's MaxContextSize).
+    uint_value: 32768
+    display_category: Model
+  - name: OutputLimit
+    display_name: >-
+      Maximum tokens the model may generate per reply. Reasoning models spend part of this
+      budget before emitting any text, so keep it generous.
+    uint_value: 8192
+    display_category: Model
+
+  - name: EndpointAuth
+    display_name: >-
+      How to authenticate to the endpoint. 'fuzzball-token' suits a Fuzzball endpoint whose
+      scope is not public: this workflow mints an endpoint access token with its own injected
+      identity, and any ApiKey rides the x-litellm-api-key header, which the Fuzzball endpoint
+      proxy leaves alone. 'api-key' suits a public Fuzzball endpoint or a third-party API,
+      where ApiKey is sent as the bearer token.
+    string_value: fuzzball-token
+    options_input:
+      options: [fuzzball-token, api-key]
+    display_category: Model
+  - name: ApiKeySecret
+    display_name: >-
+      Fuzzball secret (secret://user/<name>) holding the model API key, e.g. the LiteLLM key of
+      a vllm or litellm workflow. Injected at runtime and never stored in the rendered
+      definition. Preferred over ApiKey.
+    secret_value:
+      reference: ""
+    display_category: Model
+  - name: ApiKey
+    display_name: >-
+      Model API key in plain text, stored in the rendered definition (prefer ApiKeySecret).
+      Required with EndpointAuth=api-key.
+    string_value: ""
+    display_category: Model
+  - name: TokenLifetime
+    display_name: >-
+      Seconds the minted endpoint access token is requested for, when
+      EndpointAuth=fuzzball-token. The token is minted once at start and not renewed, so this
+      bounds how long the server keeps working; restart the workflow to mint a fresh one. The
+      server caps the grant at its own limit, at most 7 days.
+    uint_value: 604800
+    display_category: Model
+
+  - name: ServiceScope
+    display_name: >-
+      Who can reach the OpenCode server endpoint. Anyone who reaches it can run shell commands
+      and edit files in this workflow's container, so keep it as narrow as the people using it.
+      Note 'public' is served without any Fuzzball authentication, leaving the generated server
+      password as the only barrier -- but it is the only scope a local 'opencode attach' can
+      use, because the Fuzzball endpoint proxy consumes the Authorization header that attach's
+      basic-auth credentials would travel in.
+    string_value: user
+    options_input:
+      options: [user, group, organization, public]
+    display_category: Access
+
+  - name: Volume
+    display_name: >-
+      Volume holding the workspace, sessions, and message history: 'ephemeral' (default;
+      everything is destroyed when the workflow stops) or the name of an existing persistent
+      volume to keep work across restarts. Mounted at /data, with the working directory at
+      /data/workspace.
+    string_value: ephemeral
+    display_category: Storage
+
+  - name: ClusterCASecret
+    display_name: >-
+      Fuzzball secret holding the cluster's PEM certificate authority. Needed only on clusters
+      that serve a private CA and predate the node trust store being mounted into workflow
+      containers; on newer clusters leave this empty and the mounted trust store is used.
+      Without either, OpenCode cannot reach a Fuzzball endpoint over TLS.
+    secret_value:
+      reference: ""
+    display_category: Access
+
+  - name: Cores
+    display_name: CPU cores for the OpenCode server.
+    uint_value: 4
+    display_category: Resources
+  - name: Memory
+    display_name: Memory for the OpenCode server.
+    string_value: 8GiB
+    display_category: Resources
+
+  - name: Image
+    display_name: OpenCode container image.
+    string_value: docker://ghcr.io/anomalyco/opencode:1.18.23
+    display_category: Versions
+  - name: CurlImage
+    display_name: Image used by the short-lived job that mints the endpoint access token.
+    string_value: docker://curlimages/curl:8.17.0
+    display_category: Versions


### PR DESCRIPTION
Runs [OpenCode](https://opencode.ai) as a Fuzzball service, wired to a model already served on the cluster by the `vllm` or `litellm` entry.

- Runs `opencode serve` against an OpenAI-compatible endpoint, keeping the workspace, sessions, and message history on the workflow's volume.
- Authenticates to the model endpoint on its own: a short job mints an endpoint access token with the workflow's injected identity, and the model's own key rides the `x-litellm-api-key` header, which the endpoint proxy leaves untouched where it consumes `Authorization`. `EndpointAuth=api-key` sends the key as the bearer token instead and mints nothing.
- Publishes the server on one endpoint at the configured scope, and sets the generated basic-auth password only at `public` scope, the one scope whose requests can still carry it.
- Points `NODE_EXTRA_CA_CERTS` at `root-ca.crt` in the node trust store that Fuzzball mounts into workflow containers, because the Bun runtime ignores the injected `SSL_CERT_DIR`. This is why the entry needs a cluster carrying that mount.
- Probes `/global/health` rather than a synthetic path, since every unknown path answers 200 with the web application's HTML.

Two constraints worth knowing before reviewing the access model, both documented in `metadata.md`:

- A provider defined in configuration appears in OpenCode 1.18.23's v1 API but not the v2 API its bundled web application queries, so the web model picker does not offer this model and quietly falls back to OpenCode's own hosted models over the internet. The server is driven through the v1 session API or a locally attached client instead.
- `opencode attach` sends only basic-auth credentials, in the `Authorization` header a non-public endpoint's proxy consumes. Attaching a local client therefore requires `ServiceScope=public`, where the generated password is the sole barrier; the entry defaults to `user` instead and says so.

## Testing

- Renders and validates in three configurations: defaults (empty `Endpoint`), `EndpointAuth=fuzzball-token` with `ServiceScope=group`, and `EndpointAuth=api-key` with `ServiceScope=public`. Each produces only its intended branches -- mint job, password env, and LiteLLM header appear exactly where expected. Every declared value is referenced and every reference declared.
- Started against a live cluster serving `openai/gpt-oss-20b` through the `vllm` entry's in-workflow LiteLLM proxy on a group-scope endpoint. The mint job minted an access token for that endpoint, the server reported `{"healthy":true,"version":"1.18.23"}` through its own group-scope endpoint, and the custom provider appeared in the server's provider list.
- Drove an agentic turn over the v1 session API: the model called the write tool and the file landed on the workflow volume with the expected contents, confirming the full path from the served agent through the proxy to the model.
- Confirmed the web application's limitation rather than inferring it. A browser session on the served instance ran to completion, but the server records its provider as `opencode` (the model shown was `Big Pickle`, `providerID: opencode`), and `/api/model` lists no `fuzzball` model. The UI works; it just cannot select the cluster-hosted model.
- Ran on an arm64 substrate node. The live runs above predate this branch's switch to the node trust store, so they used a secret-supplied CA; the trust-store path itself is read from the merged bind-mount and still needs one run on a cluster carrying it.

----

Running locally in cluster mode
<img width="2286" height="1492" alt="image" src="https://github.com/user-attachments/assets/85b4adcb-fcb4-4ee1-9af7-44bfc87d9bae" />

Running via web UI endpoint 
<img width="2304" height="2146" alt="image" src="https://github.com/user-attachments/assets/496203a2-4b1a-4ba9-992e-bbdd92223a17" />


